### PR TITLE
fix: 调试工具优先读取插件配置中的 embedding provider

### DIFF
--- a/debug_tool/utils/config_loader.py
+++ b/debug_tool/utils/config_loader.py
@@ -43,10 +43,12 @@ class ConfigLoader:
         retrieval = plugin_config.get("retrieval", {}) or {}
         configured_provider_id = retrieval.get("embedding_provider_id", "")
 
+        # 一次性读取 cmd_config.json，复用
+        config = self.load_config()
+        providers = config.get("provider", [])
+
         # 2. 如果配置了 provider_id，在 cmd_config.json 中查找对应的 provider
         if configured_provider_id:
-            config = self.load_config()
-            providers = config.get("provider", [])
             for p in providers:
                 if p.get("id") == configured_provider_id and p.get("enable"):
                     return p
@@ -57,8 +59,6 @@ class ConfigLoader:
             )
 
         # 3. 回退：查找第一个启用的 embedding provider
-        config = self.load_config()
-        providers = config.get("provider", [])
         fallback_provider = None
         for p in providers:
             if p.get("enable") and (p.get("type") == "openai_embedding" or p.get("provider_type") == "embedding"):
@@ -89,10 +89,12 @@ class ConfigLoader:
         retrieval = plugin_config.get("retrieval", {}) or {}
         configured_provider_id = retrieval.get("embedding_provider_id", "")
 
+        # 一次性读取 cmd_config.json，复用
+        config = self.load_config()
+        providers = config.get("provider", [])
+
         # 2. 如果配置了 provider_id，在 cmd_config.json 中查找对应的 provider
         if configured_provider_id:
-            config = self.load_config()
-            providers = config.get("provider", [])
             for p in providers:
                 if p.get("id") == configured_provider_id and p.get("enable"):
                     return {
@@ -109,8 +111,6 @@ class ConfigLoader:
             }
 
         # 3. 回退：查找第一个启用的 embedding provider
-        config = self.load_config()
-        providers = config.get("provider", [])
         fallback_provider = None
         for p in providers:
             if p.get("enable") and (p.get("type") == "openai_embedding" or p.get("provider_type") == "embedding"):


### PR DESCRIPTION
## 问题描述

调试工具（debug_tool）读取的 embedding provider 与实际运行时不一致：

- **调试工具**：读取 `data/cmd_config.json` 中第一个启用的 embedding provider
- **实际运行**：读取插件配置 `data/config/astrbot_plugin_angel_memory_config.json` 中 `retrieval.embedding_provider_id` 指定的 provider

这导致用户在插件配置中设置了 embedding provider，但调试 UI 显示的是另一个 provider，造成困惑。

## 修复内容

修改 `debug_tool/utils/config_loader.py` 中的 `get_embedding_provider()` 方法：

1. 优先读取插件配置中的 `retrieval.embedding_provider_id`
2. 在 `cmd_config.json` 中查找对应的 provider
3. 回退逻辑保持不变
4. 为了让用户感知到错误，添加了各类错误提醒。

## 关联 Issue

Fixes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化改进**
  * 增强嵌入模型提供者配置加载，支持读取插件级配置并优先使用，改进容错与降级逻辑。
  * 在系统概览中新增提供者状态信息，便于了解解析与回退情况。
* **新特性**
  * 当发生提供者回退时，侧边栏会显示警告提示，提醒用户当前使用的实际提供者。
* **文档**
  * 补充了中文说明与注释以便维护与理解。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->