### PR TITLE
fix: 防止<system_context>的内容被保存在对话历史中

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this plugin will be documented in this file.
 
+## [1.3.9] - 2026-03-22
+
+### Highlights
+- 修复 `system_context` 注入策略：仅在拿不到天使之心 `secretary_decision` 时，才使用 `_no_save` 注入，避免历史污染与行为回归。
+
+### Bug Fixes
+- `fix(injection)`: `DeepMind` 新增 `has_secretary_decision` 标志并传递到注入服务。
+- `fix(injection)`: `DeepMindInjectionService` 按标志分流注入路径。
+- `fix(injection)`: 有决策时走 `extra_user_content_parts(TextPart)`；无决策时走 `request.contexts` 且 `_no_save=True`。
+
 ## [1.3.8] - 2026-03-21
 
 ### Highlights

--- a/core/deepmind.py
+++ b/core/deepmind.py
@@ -265,13 +265,22 @@ class DeepMind:
         return self.injection_service.create_tendency_bar(normalized_value)
 
     def _inject_memories_to_request(
-        self, request: ProviderRequest, session_id: str, note_context: str, soul_state_values: Optional[Dict[str, Any]] = None
+        self,
+        request: ProviderRequest,
+        session_id: str,
+        note_context: str,
+        soul_state_values: Optional[Dict[str, Any]] = None,
+        has_secretary_decision: bool = False,
     ) -> None:
         """
         将记忆、笔记和灵魂状态统一注入到LLM请求中（使用 extra_user_content_parts）
         """
         self.injection_service.inject_memories_to_request(
-            request, session_id, note_context, soul_state_values
+            request,
+            session_id,
+            note_context,
+            soul_state_values,
+            has_secretary_decision,
         )
 
     async def _update_memory_system(
@@ -430,7 +439,14 @@ class DeepMind:
                 self.logger.warning(f"获取灵魂状态值失败: {e}")
 
         # 8. 注入记忆、笔记和灵魂状态到请求
-        self._inject_memories_to_request(request, session_id, note_context, soul_state_values)
+        has_secretary_decision = bool(secretary_decision)
+        self._inject_memories_to_request(
+            request,
+            session_id,
+            note_context,
+            soul_state_values,
+            has_secretary_decision=has_secretary_decision,
+        )
 
         # 9. (异步任务所需) 将原始上下文数据存入event.angelmemory_context
         try:

--- a/core/services/injection_service.py
+++ b/core/services/injection_service.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional
 
 from astrbot.api.provider import ProviderRequest
-from astrbot.core.agent.message import TextPart
 
 
 class DeepMindInjectionService:
@@ -96,5 +95,12 @@ class DeepMindInjectionService:
                 + "\n\n".join(system_context_parts)
                 + "\n</system_context>"
             )
-            text_part = TextPart(text=full_system_context)
-            request.extra_user_content_parts.append(text_part)
+
+            #作为独立的用户角色上下文条目注入，并设置 _no_save=True，
+            #这样 AstrBot 的 _save_to_history() 将跳过它，并且它不会在对话数据库中跨轮次累积
+            #这里只考虑私聊的情况
+            request.contexts.append({
+                "role": "user",
+                "content": full_system_context,
+                "_no_save": True,
+            })

--- a/core/services/injection_service.py
+++ b/core/services/injection_service.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 from astrbot.api.provider import ProviderRequest
+from astrbot.core.agent.message import TextPart
 
 
 class DeepMindInjectionService:
@@ -35,6 +36,7 @@ class DeepMindInjectionService:
         session_id: str,
         note_context: str,
         soul_state_values: Optional[Dict[str, Any]] = None,
+        has_secretary_decision: bool = False,
     ) -> None:
         deepmind = self.deepmind
         system_context_parts = []
@@ -96,11 +98,15 @@ class DeepMindInjectionService:
                 + "\n</system_context>"
             )
 
-            #作为独立的用户角色上下文条目注入，并设置 _no_save=True，
-            #这样 AstrBot 的 _save_to_history() 将跳过它，并且它不会在对话数据库中跨轮次累积
-            #这里只考虑私聊的情况
-            request.contexts.append({
-                "role": "user",
-                "content": full_system_context,
-                "_no_save": True,
-            })
+            # 只有拿不到天使之心决策时，才使用 _no_save 的上下文注入方式，避免污染历史。
+            if not has_secretary_decision:
+                request.contexts.append(
+                    {
+                        "role": "user",
+                        "content": full_system_context,
+                        "_no_save": True,
+                    }
+                )
+            else:
+                text_part = TextPart(text=full_system_context)
+                request.extra_user_content_parts.append(text_part)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ name: astrbot_plugin_angel_memory
 display_name: 天使之魂
 description: "赋予AI动态演化的人格、长期记忆与自主学习能力，将聊天工具升级为有生命感的AI伙伴。"
 author: kawayiYokami
-version: 1.3.8
+version: 1.3.9
 repo: https://github.com/kawayiYokami/astrbot_plugin_angel_memory


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **版本**
  * 发布 v1.3.9，改进了系统上下文注入策略。
* **优化**
  * 在无法获得秘书/决策内容时，注入的系统上下文将标记为“不保存”，以避免污染历史记录和行为回归。
* **修复**
  * 根据是否存在决策，调整注入路径以减少意外副作用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->