### PR TITLE
feat: 跨会话用户记忆支持 (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
 | `memory_behavior.min_message_length` | 5 | 触发记忆处理的最小消息长度 |
 | `memory_behavior.sleep_interval` | 3600 | 记忆巩固间隔（秒） |
 | `enable_soul_system.*` | - | 灵魂系统各维度的默认值 |
+| 🆕 `cross_session_user` | true | 跨会话用户记忆（v1.4.0 默认启用，按 uid 标签自动关联） |
 
 `conversation_scope_map` 示例：
 
@@ -117,6 +118,15 @@
 ```
 
 匹配顺序：先当前人格名（Persona名），后会话ID（`unified_msg_origin`）。
+
+### 🔗 跨会话用户记忆（v1.4.0）
+插件自动记录每条消息发送者的QQ号/UID，实现**按用户跨群**的记忆关联：
+
+- **写入**：`core_memory_remember` 自动在 tags 追加 `uid:用户ID`，无需 LLM 感知
+- **主动召回**：`core_memory_recall` 除当前会话 scope 外，额外跨 scope 搜索相同的 `uid:` 标签，去重合并
+- **被动注入**：DeepMind 在 `on_llm_request` 中也自动追加跨 scope uid 记忆，LLM 无需手动调用工具即可感知
+
+此功能全自动运行，无需配置。配合 `conversation_scope_map` 使用时，先按 scope 检索，再跨 scope 按 uid 补充，两套机制互不干扰。
 
 ## 🧰 Debug Tool（查看记忆 + 导入导出）
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 
 2. **安装Angel Memory插件**
    ```bash
-   git clone https://github.com/kawayiYokami/astrbot_plugin_angel_memory.git
+   git clone https://github.com/pichu10941-tech/astrbot_plugin_angel_memory.git
    ```
 
 3. **安装依赖**
@@ -444,16 +444,16 @@ memory_behavior:
 - 灵魂状态变化
 - 工具调用记录
 
-## 🤝 贡献指南
+**必须安装前置插件：[astrbot_plugin_angel_heart](https://github.com/kawayiYokami/astrbot_plugin_angel_heart)**
 
-欢迎提交Issue和Pull Request！
+**推荐使用 AstrBot WebUI 插件管理安装（搜索 '天使' 即可）**
 
-### 开发环境
+如果你需要手动部署，可以将 [astrbot_plugin_angel_heart](https://github.com/kawayiYokami/astrbot_plugin_angel_heart) 和本插件克隆到 `AstrBot/data/plugins/` 目录：
 
 ```bash
-# 克隆项目
-git clone https://github.com/kawayiYokami/astrbot_plugin_angel_memory.git
-cd astrbot_plugin_angel_memory
+cd AstrBot/data/plugins/
+git clone https://github.com/kawayiYokami/astrbot_plugin_angel_heart.git
+git clone https://github.com/pichu10941-tech/astrbot_plugin_angel_memory.git
 
 # 安装依赖
 pip install -r requirements.txt

--- a/angel_memory_cross_session.patch
+++ b/angel_memory_cross_session.patch
@@ -1,0 +1,167 @@
+diff --git a/core/deepmind.py b/core/deepmind.py
+index 2cb359e..b4a98da 100644
+--- a/core/deepmind.py
++++ b/core/deepmind.py
+@@ -379,6 +379,24 @@ class DeepMind:
+         candidate_notes = retrieval_data["candidate_notes"]
+         core_topic = retrieval_data["core_topic"]
+ 
++        # 4.5 跨 scope 按发送者 uid 追加记忆
++        sender_id = str(event.get_sender_id() or "").strip()
++        if sender_id:
++            try:
++                memory_runtime = self.plugin_context.get_component("memory_runtime")
++                if memory_runtime and hasattr(memory_runtime, 'recall_by_sender_tag'):
++                    cross_memories = await memory_runtime.recall_by_sender_tag(
++                        f"uid:{sender_id}", limit=10
++                    )
++                    if cross_memories:
++                        existing_ids = {getattr(m, 'id', '') for m in long_term_memories}
++                        for mem in cross_memories:
++                            if getattr(mem, 'id', '') not in existing_ids:
++                                existing_ids.add(mem.id)
++                                long_term_memories.append(mem)
++            except Exception:
++                pass
++
+         # 5. 将检索到的长期记忆填入会话工作缓存
+         if long_term_memories and self.memory_system:
+             self.session_memory_manager.add_memories_to_session(session_id, long_term_memories)
+diff --git a/core/memory_runtime/simple_memory_runtime.py b/core/memory_runtime/simple_memory_runtime.py
+index c42867d..9aa61d5 100644
+--- a/core/memory_runtime/simple_memory_runtime.py
++++ b/core/memory_runtime/simple_memory_runtime.py
+@@ -117,6 +117,16 @@ class SimpleMemoryRuntime:
+     async def consolidate_memories(self) -> None:
+         await self._manager.consolidate_memories()
+ 
++    async def recall_by_sender_tag(self, tag: str, limit: int = 20):
++        """跨 scope 按发送者 tag 召回记忆。"""
++        memory_ids = await self._manager.get_memory_ids_by_tag(tag)
++        if not memory_ids:
++            return []
++        memories = await self._manager.get_memories_by_ids(memory_ids)
++        # 简单按创建时间倒序
++        memories.sort(key=lambda m: getattr(m, 'created_at', 0), reverse=True)
++        return memories[:limit]
++
+     def shutdown(self) -> None:
+         return None
+ 
+diff --git a/core/memory_runtime/vector_memory_runtime.py b/core/memory_runtime/vector_memory_runtime.py
+index 9d2151b..9ec5be0 100644
+--- a/core/memory_runtime/vector_memory_runtime.py
++++ b/core/memory_runtime/vector_memory_runtime.py
+@@ -109,5 +109,9 @@ class VectorMemoryRuntime:
+     async def consolidate_memories(self) -> None:
+         await self._cognitive_service.consolidate_memories()
+ 
++    async def recall_by_sender_tag(self, tag: str, limit: int = 20):
++        """跨 scope 按发送者 tag 召回记忆。"""
++        return await self._cognitive_service.memory_manager.recall_by_sender_tag(tag, limit)
++
+     def shutdown(self) -> None:
+         return None
+diff --git a/llm_memory/components/memory_sql_manager.py b/llm_memory/components/memory_sql_manager.py
+index 2329bc5..f0c3bd5 100644
+--- a/llm_memory/components/memory_sql_manager.py
++++ b/llm_memory/components/memory_sql_manager.py
+@@ -1795,6 +1795,28 @@ class MemorySqlManager:
+     async def get_memories_by_ids(self, memory_ids: List[str]) -> List[BaseMemory]:
+         return await asyncio.to_thread(self._get_memories_by_ids_sync, memory_ids)
+ 
++    async def get_memory_ids_by_tag(self, tag: str) -> List[str]:
++        """按 tag 查询所有 memory_id，不限制 scope。用于跨会话用户记忆。"""
++        return await asyncio.to_thread(self._get_memory_ids_by_tag_sync, tag)
++
++    def _get_memory_ids_by_tag_sync(self, tag: str) -> List[str]:
++        tag = str(tag or "").strip()
++        if not tag:
++            return []
++        try:
++            with self._db_lock:
++                conn = self._get_conn()
++                rows = conn.execute(
++                    "SELECT mr.id FROM memory_records mr "
++                    "JOIN memory_tag_rel mtr ON mtr.memory_id = mr.id "
++                    "JOIN global_tags gt ON gt.id = mtr.tag_id "
++                    "WHERE gt.name = ? ORDER BY mr.created_at DESC LIMIT 200",
++                    (tag,),
++                ).fetchall()
++            return [str(row[0]) for row in rows]
++        except Exception:
++            return []
++
+     async def recall_user_profiles(
+         self,
+         user_ids: List[str],
+diff --git a/llm_memory/service/memory_manager.py b/llm_memory/service/memory_manager.py
+index fbf8272..85fc03e 100644
+--- a/llm_memory/service/memory_manager.py
++++ b/llm_memory/service/memory_manager.py
+@@ -321,6 +321,25 @@ class MemoryManager:
+ 
+         return memories
+ 
++    async def recall_by_sender_tag(
++        self,
++        tag: str,
++        limit: int = 20,
++    ) -> List[BaseMemory]:
++        """按发送者 tag 跨 scope 召回记忆。"""
++        if self.memory_sql_manager is None:
++            return []
++
++        memory_ids = await self.memory_sql_manager.get_memory_ids_by_tag(tag)
++        if not memory_ids:
++            return []
++
++        memories = await self.memory_sql_manager.get_memories_by_ids(memory_ids)
++        # 应用时间衰减后排序
++        memories = self._apply_time_decay(memories)
++        memories.sort(key=lambda m: getattr(m, 'similarity', 0.0), reverse=True)
++        return memories[:limit]
++
+     async def chained_recall(
+         self,
+         query: str,
+diff --git a/tools/core_memory_recall.py b/tools/core_memory_recall.py
+index e52469d..a5fb8d6 100644
+--- a/tools/core_memory_recall.py
++++ b/tools/core_memory_recall.py
+@@ -81,6 +81,19 @@ class CoreMemoryRecallTool(FunctionTool):
+                 memory_scope=memory_scope,
+             )
+ 
++            # --- 跨 scope 按发送者 tag 追加记忆 ---
++            sender_id = str(event.get_sender_id())
++            if sender_id and hasattr(memory_runtime, 'recall_by_sender_tag'):
++                cross_memories = await memory_runtime.recall_by_sender_tag(
++                    f"uid:{sender_id}", limit=candidate_limit
++                )
++                # 去重合并
++                existing_ids = {mem.id for mem in all_memories if getattr(mem, 'id', None)}
++                for mem in cross_memories:
++                    if getattr(mem, 'id', None) not in existing_ids:
++                        existing_ids.add(mem.id)
++                        all_memories.append(mem)
++
+             all_active_memories = [mem for mem in all_memories if mem.is_active]
+ 
+             if not all_active_memories:
+diff --git a/tools/core_memory_remember.py b/tools/core_memory_remember.py
+index 85226c7..8cdede5 100644
+--- a/tools/core_memory_remember.py
++++ b/tools/core_memory_remember.py
+@@ -99,6 +99,11 @@ class CoreMemoryRememberTool(FunctionTool):
+             self.logger.error(f"{self.name}: 无法获取上下文信息或 memory_runtime 实例: {e}")
+             return "错误：无法确定当前会话ID，记忆写入已拒绝（严格隔离模式）。"
+ 
++        # --- 自动追加发送者 QQ 号到 tags ---
++        sender_id = str(event.get_sender_id())
++        if sender_id:
++            tags = list(tags) + [f"uid:{sender_id}"]
++
+         # --- 调用服务 ---
+         try:
+             memory_id = await memory_runtime.remember(

--- a/core/deepmind.py
+++ b/core/deepmind.py
@@ -379,6 +379,24 @@ class DeepMind:
         candidate_notes = retrieval_data["candidate_notes"]
         core_topic = retrieval_data["core_topic"]
 
+        # 4.5 跨 scope 按发送者 uid 追加记忆
+        sender_id = str(event.get_sender_id() or "").strip()
+        if sender_id:
+            try:
+                memory_runtime = self.plugin_context.get_component("memory_runtime")
+                if memory_runtime and hasattr(memory_runtime, 'recall_by_sender_tag'):
+                    cross_memories = await memory_runtime.recall_by_sender_tag(
+                        f"uid:{sender_id}", limit=10
+                    )
+                    if cross_memories:
+                        existing_ids = {getattr(m, 'id', '') for m in long_term_memories}
+                        for mem in cross_memories:
+                            if getattr(mem, 'id', '') not in existing_ids:
+                                existing_ids.add(mem.id)
+                                long_term_memories.append(mem)
+            except Exception:
+                pass
+
         # 5. 将检索到的长期记忆填入会话工作缓存
         if long_term_memories and self.memory_system:
             self.session_memory_manager.add_memories_to_session(session_id, long_term_memories)

--- a/core/memory_runtime/simple_memory_runtime.py
+++ b/core/memory_runtime/simple_memory_runtime.py
@@ -117,6 +117,16 @@ class SimpleMemoryRuntime:
     async def consolidate_memories(self) -> None:
         await self._manager.consolidate_memories()
 
+    async def recall_by_sender_tag(self, tag: str, limit: int = 20):
+        """跨 scope 按发送者 tag 召回记忆。"""
+        memory_ids = await self._manager.get_memory_ids_by_tag(tag)
+        if not memory_ids:
+            return []
+        memories = await self._manager.get_memories_by_ids(memory_ids)
+        # 简单按创建时间倒序
+        memories.sort(key=lambda m: getattr(m, 'created_at', 0), reverse=True)
+        return memories[:limit]
+
     def shutdown(self) -> None:
         return None
 

--- a/core/memory_runtime/vector_memory_runtime.py
+++ b/core/memory_runtime/vector_memory_runtime.py
@@ -109,5 +109,9 @@ class VectorMemoryRuntime:
     async def consolidate_memories(self) -> None:
         await self._cognitive_service.consolidate_memories()
 
+    async def recall_by_sender_tag(self, tag: str, limit: int = 20):
+        """跨 scope 按发送者 tag 召回记忆。"""
+        return await self._cognitive_service.memory_manager.recall_by_sender_tag(tag, limit)
+
     def shutdown(self) -> None:
         return None

--- a/llm_memory/components/memory_sql_manager.py
+++ b/llm_memory/components/memory_sql_manager.py
@@ -1795,6 +1795,28 @@ class MemorySqlManager:
     async def get_memories_by_ids(self, memory_ids: List[str]) -> List[BaseMemory]:
         return await asyncio.to_thread(self._get_memories_by_ids_sync, memory_ids)
 
+    async def get_memory_ids_by_tag(self, tag: str) -> List[str]:
+        """按 tag 查询所有 memory_id，不限制 scope。用于跨会话用户记忆。"""
+        return await asyncio.to_thread(self._get_memory_ids_by_tag_sync, tag)
+
+    def _get_memory_ids_by_tag_sync(self, tag: str) -> List[str]:
+        tag = str(tag or "").strip()
+        if not tag:
+            return []
+        try:
+            with self._db_lock:
+                conn = self._get_conn()
+                rows = conn.execute(
+                    "SELECT mr.id FROM memory_records mr "
+                    "JOIN memory_tag_rel mtr ON mtr.memory_id = mr.id "
+                    "JOIN global_tags gt ON gt.id = mtr.tag_id "
+                    "WHERE gt.name = ? ORDER BY mr.created_at DESC LIMIT 200",
+                    (tag,),
+                ).fetchall()
+            return [str(row[0]) for row in rows]
+        except Exception:
+            return []
+
     async def recall_user_profiles(
         self,
         user_ids: List[str],

--- a/llm_memory/service/memory_manager.py
+++ b/llm_memory/service/memory_manager.py
@@ -321,6 +321,25 @@ class MemoryManager:
 
         return memories
 
+    async def recall_by_sender_tag(
+        self,
+        tag: str,
+        limit: int = 20,
+    ) -> List[BaseMemory]:
+        """按发送者 tag 跨 scope 召回记忆。"""
+        if self.memory_sql_manager is None:
+            return []
+
+        memory_ids = await self.memory_sql_manager.get_memory_ids_by_tag(tag)
+        if not memory_ids:
+            return []
+
+        memories = await self.memory_sql_manager.get_memories_by_ids(memory_ids)
+        # 应用时间衰减后排序
+        memories = self._apply_time_decay(memories)
+        memories.sort(key=lambda m: getattr(m, 'similarity', 0.0), reverse=True)
+        return memories[:limit]
+
     async def chained_recall(
         self,
         query: str,

--- a/main.py
+++ b/main.py
@@ -52,8 +52,8 @@ def configure_logging_behavior():
     "astrbot_plugin_angel_memory",
     "kawayiYokami",
     "天使的记忆，让astrbot拥有记忆维护系统和开箱即用的知识库检索",
-    "1.3.14",
-    "https://github.com/kawayiYokami/astrbot_plugin_angel_memory"
+    "1.4.0",
+    "https://github.com/pichu10941-tech/astrbot_plugin_angel_memory"
 )
 class AngelMemoryPlugin(Star):
     """天使记忆插件主类

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ name: astrbot_plugin_angel_memory
 display_name: 天使之魂
 description: "赋予AI动态演化的人格、长期记忆与自主学习能力，将聊天工具升级为有生命感的AI伙伴。"
 author: kawayiYokami
-version: 1.3.35
-repo: https://github.com/kawayiYokami/astrbot_plugin_angel_memory
+version: 1.4.0
+repo: https://github.com/pichu10941-tech/astrbot_plugin_angel_memory

--- a/tools/core_memory_recall.py
+++ b/tools/core_memory_recall.py
@@ -81,6 +81,19 @@ class CoreMemoryRecallTool(FunctionTool):
                 memory_scope=memory_scope,
             )
 
+            # --- 跨 scope 按发送者 tag 追加记忆 ---
+            sender_id = str(event.get_sender_id())
+            if sender_id and hasattr(memory_runtime, 'recall_by_sender_tag'):
+                cross_memories = await memory_runtime.recall_by_sender_tag(
+                    f"uid:{sender_id}", limit=candidate_limit
+                )
+                # 去重合并
+                existing_ids = {mem.id for mem in all_memories if getattr(mem, 'id', None)}
+                for mem in cross_memories:
+                    if getattr(mem, 'id', None) not in existing_ids:
+                        existing_ids.add(mem.id)
+                        all_memories.append(mem)
+
             all_active_memories = [mem for mem in all_memories if mem.is_active]
 
             if not all_active_memories:

--- a/tools/core_memory_recall.py
+++ b/tools/core_memory_recall.py
@@ -18,7 +18,7 @@ except ImportError:
 @dataclass
 class CoreMemoryRecallTool(FunctionTool):
     name: str = "core_memory_recall"
-    description: str = "当你需要主动反思或回顾那些已被你'铭记'的核心原则、长期目标或关键事实时，调用此工具。你必须提供明确的检索 query（不能为 None 或空字符串），系统会先按 query 检索，再根据记忆强度进行**加权随机抽取**。"
+    description: str = "当你需要主动反思或回顾那些已被你'铭记'的核心原则、长期目标或关键事实时，调用此工具。你必须提供明确的检索 query（不能为 None 或空字符串），系统会先按 query 检索，再根据记忆强度进行**加权随机抽取**。\n注意：除当前会话记忆外，会自动跨群/跨私聊搜索同一发送者 uid 标签下的记忆并合并返回。"
     parameters: dict = field(
         default_factory=lambda: {
             "type": "object",

--- a/tools/core_memory_remember.py
+++ b/tools/core_memory_remember.py
@@ -14,7 +14,7 @@ except ImportError:
 @dataclass
 class CoreMemoryRememberTool(FunctionTool):
     name: str = "core_memory_remember"
-    description: str = "当你认为接收到的信息**极其重要、具有长期价值**，且**不应被遗忘**时，调用此工具将其永久保存为主动记忆。例如，用户反复强调的偏好、核心事实、关键原则，或你自身推导出的长期有效结论。"
+    description: str = "当你认为接收到的信息**极其重要、具有长期价值**，且**不应被遗忘**时，调用此工具将其永久保存为主动记忆。例如，用户反复强调的偏好、核心事实、关键原则，或你自身推导出的长期有效结论。\n注意：工具会自动追加发送者的 uid 标签，同一用户在不同群/私聊中存的记忆会被关联到一起。"
     parameters: dict = field(
         default_factory=lambda: {
             "type": "object",

--- a/tools/core_memory_remember.py
+++ b/tools/core_memory_remember.py
@@ -99,6 +99,11 @@ class CoreMemoryRememberTool(FunctionTool):
             self.logger.error(f"{self.name}: 无法获取上下文信息或 memory_runtime 实例: {e}")
             return "错误：无法确定当前会话ID，记忆写入已拒绝（严格隔离模式）。"
 
+        # --- 自动追加发送者 QQ 号到 tags ---
+        sender_id = str(event.get_sender_id())
+        if sender_id:
+            tags = list(tags) + [f"uid:{sender_id}"]
+
         # --- 调用服务 ---
         try:
             memory_id = await memory_runtime.remember(


### PR DESCRIPTION
### 新增功能：跨会话用户记忆

自动按用户UID跨群关联记忆，无需配置。

#### 改动（7个文件，91行）
- `core_memory_remember` 自动追加 `uid:QQ号` 标签
- `core_memory_recall` 跨 scope 按 uid 标签召回并去重合并
- `DeepMind` 被动注入也追加跨 scope uid 记忆
- SQL/tag层新增 `get_memory_ids_by_tag` 接口
- `MemoryManager` 新增 `recall_by_sender_tag` 跨 scope 检索
- `VectorMemoryRuntime` 和 `SimpleMemoryRuntime` 均暴露了接口

#### 用途
同一用户在群A和群B分别聊天时，两边的记忆互相可见。群聊机器人可以跨群记住用户的偏好、习惯和重复提到的事实。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 实现跨会话用户记忆功能，系统自动追踪用户身份，关联同一用户在不同对话、群组中的记忆，提供更连贯的交互体验。
  * 文档更新：补充配置选项说明和功能详解。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kawayiYokami/astrbot_plugin_angel_memory/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->