### PR TITLE
fix(embedding): 兼容聚合向量返回

### DIFF
--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -762,6 +762,13 @@ class APIEmbeddingProvider(EmbeddingProvider):
         """
         full_embeddings = [None] * original_count
 
+        if len(unique_embeddings) != len(unique_to_original):
+            raise RuntimeError(
+                "嵌入提供商返回数量不匹配: "
+                f"provider_id={self.provider_id} 请求去重后数量={len(unique_to_original)} "
+                f"返回数量={len(unique_embeddings)}"
+            )
+
         for unique_idx, original_indices in enumerate(unique_to_original):
             embedding = unique_embeddings[unique_idx]
             for original_idx in original_indices:
@@ -779,6 +786,8 @@ class APIEmbeddingProvider(EmbeddingProvider):
                 if batch_size >= len(texts):
                     # 单批次处理
                     result = await self.provider.get_embeddings(texts)
+                    result = self._expand_aggregated_embedding(result, texts)
+                    self._validate_embedding_count(result, texts)
                     return result
                 else:
                     # 分批并发处理
@@ -793,7 +802,12 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
                     # 按顺序拼接结果
                     result = []
-                    for batch_embeddings in batch_results:
+                    batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
+                    for batch, batch_embeddings in zip(batches, batch_results):
+                        batch_embeddings = self._expand_aggregated_embedding(
+                            batch_embeddings, batch
+                        )
+                        self._validate_embedding_count(batch_embeddings, batch)
                         result.extend(batch_embeddings)
 
                     return result
@@ -809,6 +823,50 @@ class APIEmbeddingProvider(EmbeddingProvider):
                     # 继续循环用新的batch_size重试
                 else:
                     raise
+
+    def _expand_aggregated_embedding(
+        self, embeddings: List[List[float]], texts: List[str]
+    ) -> List[List[float]]:
+        """
+        兼容上游对多输入返回单个聚合向量的行为。
+
+        上游 provider 仍负责请求与解析；这里仅把符合结构特征的聚合结果
+        扩展为本批次所需的向量数量，避免后续 FAISS 回填因数量不一致失败。
+        """
+        if self._is_aggregated_embedding_result(embeddings, texts):
+            self.logger.warning(
+                "嵌入提供商返回聚合向量，已扩展到批次内所有文本: "
+                f"provider_id={self.provider_id} 请求数量={len(texts)} 返回数量=1"
+            )
+            return [list(embeddings[0]) for _ in texts]
+        return embeddings
+
+    @staticmethod
+    def _is_aggregated_embedding_result(
+        embeddings: List[List[float]], texts: List[str]
+    ) -> bool:
+        """判断是否符合“多输入返回单条聚合向量”的结构特征。"""
+        return (
+            len(texts) > 1
+            and len(embeddings) == 1
+            and isinstance(embeddings[0], list)
+            and len(embeddings[0]) > 0
+        )
+
+    def _validate_embedding_count(
+        self, embeddings: List[List[float]], texts: List[str]
+    ) -> None:
+        """校验上游返回数量，避免不完整向量结果写入索引。"""
+        if len(embeddings) == len(texts):
+            return
+        preview = str(texts[len(embeddings)] if len(embeddings) < len(texts) else texts[-1])
+        if len(preview) > 80:
+            preview = preview[:77] + "..."
+        raise RuntimeError(
+            "嵌入提供商返回数量不匹配: "
+            f"provider_id={self.provider_id} 请求数量={len(texts)} 返回数量={len(embeddings)} "
+            f"首个缺失文本={preview!r}"
+        )
 
     @staticmethod
     def _is_batch_too_large_error(e: Exception) -> bool:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ name: astrbot_plugin_angel_memory
 display_name: 天使之魂
 description: "赋予AI动态演化的人格、长期记忆与自主学习能力，将聊天工具升级为有生命感的AI伙伴。"
 author: kawayiYokami
-version: 1.4.9
+version: 1.4.10
 repo: https://github.com/kawayiYokami/astrbot_plugin_angel_memory

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+
+from llm_memory.components.embedding_provider import APIEmbeddingProvider
+
+
+class ShortEmbeddingProvider:
+    async def get_embeddings(self, texts):
+        return [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+    async def get_embedding(self, text):
+        return [1.0, 0.0, 0.0]
+
+
+class AggregatingEmbeddingProvider:
+    async def get_embeddings(self, texts):
+        return [[1.0, 2.0, 3.0]]
+
+    async def get_embedding(self, text):
+        return [1.0, 2.0, 3.0]
+
+
+def test_api_embedding_provider_rejects_short_batch_results():
+    async def run():
+        provider = APIEmbeddingProvider(ShortEmbeddingProvider(), "short_provider")
+        provider._available = True
+        provider._cache_enabled = False
+
+        try:
+            await provider.embed_documents(["alpha", "beta", "gamma"])
+        except RuntimeError as exc:
+            assert "返回数量不匹配" in str(exc)
+        else:
+            raise AssertionError("expected short embedding results to fail")
+
+    asyncio.run(run())
+
+
+def test_api_embedding_provider_expands_aggregated_embedding():
+    async def run():
+        provider = APIEmbeddingProvider(AggregatingEmbeddingProvider(), "aggregating_provider")
+        provider._available = True
+        provider._cache_enabled = False
+
+        result = await provider.embed_documents(["alpha", "beta"])
+
+        assert result == [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
+
+    asyncio.run(run())


### PR DESCRIPTION
## 背景

`APIEmbeddingProvider` 目前假设批量嵌入返回数量一定与去重后的输入数量一致。实际使用中，部分上游嵌入提供商会在多输入请求时返回单条聚合向量。例如 Gemini Embedding 2 文档中说明：多个输入直接传入 `contents` 时会产生一个 aggregated embedding；如需独立 embedding，需要每个输入包装为独立 `Content`。

当上游返回数量少于输入数量时，当前实现会在 `_map_embeddings_back()` 中直接按索引回填，触发：

```text
IndexError: list index out of range
```

这会导致 FAISS 记忆索引同步失败，并且错误信息无法直接说明真实原因。

## 修改

- 在批量嵌入返回后，兼容“多输入、单条非空向量”的聚合返回结构，将聚合向量扩展为当前批次所需数量，避免同步流程崩溃。
- 对非聚合场景增加返回数量校验，避免不完整结果进入 FAISS 回填流程。
- 在 `_map_embeddings_back()` 前增加兜底校验，避免再次出现不明确的 `IndexError`。
- 增加针对聚合返回和部分缺失返回的测试。
- 按项目规则递增版本号到 `1.4.10`。

## 边界说明

这个修复是兼容性降级：当上游明确表现为“多输入返回单条聚合向量”时，插件复用该聚合向量以避免索引同步崩溃。它不会把聚合向量还原成每条输入的独立向量。

如果某个 provider 需要保证每条文本都有独立 embedding，更完整的做法仍应在 provider 层按上游 API 要求构造 batch 请求，或退回逐条请求。本 PR 的目标是让通用 `APIEmbeddingProvider` 不再因为返回数量假设而抛出 `IndexError`，同时对真正不完整的返回给出明确错误。

## 验证

已执行：

```bash
python3 -m py_compile llm_memory/components/embedding_provider.py tests/test_embedding_provider.py
python3 -c "import sys; sys.path.insert(0, '.'); from tests.test_embedding_provider import test_api_embedding_provider_rejects_short_batch_results, test_api_embedding_provider_expands_aggregated_embedding; test_api_embedding_provider_rejects_short_batch_results(); test_api_embedding_provider_expands_aggregated_embedding(); print('ok')"
```