### PR TITLE
fix: 修复某些个性化昵称（如 Null）被错误过滤的问题

### DIFF
--- a/core/deepmind.py
+++ b/core/deepmind.py
@@ -504,12 +504,12 @@ class DeepMind:
         sid = str(sender_id or "").strip()
         name = str(sender_name or "").strip()
         
-        # 核心逻辑改进：只要有合法的 ID，就认为身份有效。
-        # 只有当 ID 无效且名字也无效时，才判定为缺失身份。
+        # 核心逻辑改进: 只要有合法的 ID, 就认为身份有效。
         if sid and sid.lower() not in invalid_ids:
             return False
             
-        return sid.lower() in invalid_ids or name.lower() in invalid_names
+        # 只有当 ID 无效且名字也无效时, 才判定为缺失身份。
+        return sid.lower() in invalid_ids and name.lower() in invalid_names
 
     def _get_event_sender_identity(self, event: AstrMessageEvent) -> tuple[str, str]:
         sender_id = ""

--- a/core/deepmind.py
+++ b/core/deepmind.py
@@ -503,6 +503,12 @@ class DeepMind:
         invalid_names = {"", "用户", "成员", "未知", "未知用户", "user", "unknown", "none", "null"}
         sid = str(sender_id or "").strip()
         name = str(sender_name or "").strip()
+        
+        # 核心逻辑改进：只要有合法的 ID，就认为身份有效。
+        # 只有当 ID 无效且名字也无效时，才判定为缺失身份。
+        if sid and sid.lower() not in invalid_ids:
+            return False
+            
         return sid.lower() in invalid_ids or name.lower() in invalid_names
 
     def _get_event_sender_identity(self, event: AstrMessageEvent) -> tuple[str, str]:


### PR DESCRIPTION
### 问题描述

目前 ``AngelMemory`` 的 ``_is_missing_user_identity`` 校验逻辑过于严格，采用的是 ``ID 无效 OR 昵称无效`` 的判定策略。这导致如果用户昵称恰好是 ``Null``、``None`` 或 ``Unknown``（即便其有合法的数字 ID），也会被判定为“异常消息”并丢弃，从而无法记入长期记忆。

### 修复方案

重构校验逻辑为 **ID 优先信任制**：

1. 如果存在合法的 ``sender_id``（不在预设的无效 ID 列表中），则直接通过校验。
2. 只有在 ID 无效的情况下，才会进一步校验昵称。

此修改确保了起个性化昵称的用户（极客或特定风格用户）能被系统正常识别并记忆，同时保持了多平台的兼容性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化了用户身份验证机制，改进了身份识别的逻辑判断。现在在验证用户身份时，将优先使用发送者ID进行判断，当其有效时直接认定身份有效，无需再受发送者名称的影响，进而提升了身份识别的准确性和效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->