### PR TITLE
Refresh embedding provider reference before API calls

### DIFF
--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -609,7 +609,13 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 class APIEmbeddingProvider(EmbeddingProvider):
     """API嵌入模型提供商"""
 
-    def __init__(self, provider, provider_id: str, cache_size_mb: float = 100.0):
+    def __init__(
+        self,
+        provider,
+        provider_id: str,
+        cache_size_mb: float = 100.0,
+        context=None,
+    ):
         """
         初始化API嵌入提供商
 
@@ -620,6 +626,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
         """
         self.provider = provider
         self.provider_id = provider_id
+        self.context = context
         self.logger = logger
         self._model_info = None
         self._available = None  # None表示未测试，True/False表示测试结果
@@ -632,6 +639,26 @@ class APIEmbeddingProvider(EmbeddingProvider):
             f"API嵌入提供商已初始化: {self.provider_id}, "
             f"批量大小: {self.batch_size} (纯异步模式)"
         )
+
+    def _refresh_provider_reference(self):
+        """热重载后重新绑定 AstrBot 当前 provider 实例。"""
+        if not self.context or not hasattr(self.context, "get_provider_by_id"):
+            return self.provider
+        try:
+            current_provider = self.context.get_provider_by_id(self.provider_id)
+        except Exception as e:
+            self.logger.debug(
+                f"[简单记忆回灌] 刷新API嵌入提供商引用失败 provider_id={self.provider_id}: {e}",
+                exc_info=True,
+            )
+            return self.provider
+        if current_provider and current_provider is not self.provider:
+            self.provider = current_provider
+            self._model_info = None
+            self.logger.info(
+                f"[简单记忆回灌] API嵌入提供商已刷新当前实例 provider_id={self.provider_id}"
+            )
+        return self.provider
 
     async def check_availability(self) -> bool:
         """异步检查可用性"""
@@ -653,7 +680,8 @@ class APIEmbeddingProvider(EmbeddingProvider):
     async def _perform_embedding_test(self, text: str):
         """执行嵌入测试"""
         try:
-            await self.provider.get_embedding(text)
+            provider = self._refresh_provider_reference()
+            await provider.get_embedding(text)
         except Exception as e:
             raise e
 
@@ -784,9 +812,10 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
         while True:
             try:
+                provider = self._refresh_provider_reference()
                 if batch_size >= len(texts):
                     # 单批次处理
-                    result = await self.provider.get_embeddings(texts)
+                    result = await provider.get_embeddings(texts)
                     result = self._expand_aggregated_embedding(result, texts)
                     self._validate_embedding_count(result, texts)
                     return result
@@ -795,7 +824,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
                     tasks = []
                     for i in range(0, len(texts), batch_size):
                         batch = texts[i : i + batch_size]
-                        task = self.provider.get_embeddings(batch)
+                        task = provider.get_embeddings(batch)
                         tasks.append(task)
 
                     # 并发执行所有批次
@@ -927,6 +956,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
     def get_model_info(self) -> Dict[str, Any]:
         """获取模型信息"""
+        self._refresh_provider_reference()
         if self._model_info is None:
             meta = self.provider.meta() if hasattr(self.provider, "meta") else {}
             model_name = self._extract_api_model_name(meta)
@@ -1022,7 +1052,11 @@ class EmbeddingProviderFactory:
 
             provider = self.context.get_provider_by_id(normalized_provider_id)
             if provider:
-                api_provider = APIEmbeddingProvider(provider, normalized_provider_id)
+                api_provider = APIEmbeddingProvider(
+                    provider,
+                    normalized_provider_id,
+                    context=self.context,
+                )
                 if await api_provider.check_availability():
                     self.logger.info(f"成功使用API嵌入提供商: {normalized_provider_id}")
                     return api_provider

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ name: astrbot_plugin_angel_memory
 display_name: 天使之魂
 description: "赋予AI动态演化的人格、长期记忆与自主学习能力，将聊天工具升级为有生命感的AI伙伴。"
 author: kawayiYokami
-version: 1.4.15
+version: 1.4.16
 repo: https://github.com/kawayiYokami/astrbot_plugin_angel_memory

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -35,6 +35,47 @@ class MetaEmbeddingProvider:
         return [1.0, 0.0, 0.0]
 
 
+class ClosedEmbeddingProvider:
+    async def get_embeddings(self, texts):
+        raise RuntimeError("old provider is closed")
+
+    async def get_embedding(self, text):
+        raise RuntimeError("old provider is closed")
+
+
+class RecordingEmbeddingProvider:
+    def __init__(self):
+        self.calls = []
+
+    async def get_embeddings(self, texts):
+        self.calls.append(list(texts))
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+    async def get_embedding(self, text):
+        return [1.0, 0.0, 0.0]
+
+
+class ReplacingContext:
+    def __init__(self, replacement):
+        self.replacement = replacement
+
+    def get_provider_by_id(self, provider_id):
+        assert provider_id == "api_provider"
+        return self.replacement
+
+
+class RotatingContext:
+    def __init__(self, replacements):
+        self.replacements = list(replacements)
+        self.calls = 0
+
+    def get_provider_by_id(self, provider_id):
+        assert provider_id == "api_provider"
+        index = min(self.calls, len(self.replacements) - 1)
+        self.calls += 1
+        return self.replacements[index]
+
+
 def test_api_embedding_provider_rejects_short_batch_results():
     async def run():
         provider = APIEmbeddingProvider(ShortEmbeddingProvider(), "short_provider")
@@ -49,6 +90,69 @@ def test_api_embedding_provider_rejects_short_batch_results():
             raise AssertionError("expected short embedding results to fail")
 
     asyncio.run(run())
+
+
+def test_api_embedding_provider_refreshes_provider_reference_before_batch_request():
+    async def run():
+        replacement = MetaEmbeddingProvider({"model": "BAAI/bge-m3"})
+        provider = APIEmbeddingProvider(
+            ClosedEmbeddingProvider(),
+            "api_provider",
+            context=ReplacingContext(replacement),
+        )
+        provider._available = True
+        provider._cache_enabled = False
+
+        result = await provider.embed_documents(["alpha", "beta"])
+
+        assert result == [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+        assert provider.provider is replacement
+
+    asyncio.run(run())
+
+
+def test_api_embedding_provider_uses_one_provider_reference_per_batch_attempt():
+    async def run():
+        first = RecordingEmbeddingProvider()
+        second = RecordingEmbeddingProvider()
+        context = RotatingContext([first, second])
+        provider = APIEmbeddingProvider(
+            ClosedEmbeddingProvider(),
+            "api_provider",
+            context=context,
+        )
+        provider._available = True
+        provider._cache_enabled = False
+        provider.batch_size = 1
+
+        result = await provider.embed_documents(["alpha", "beta"])
+
+        assert result == [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+        assert context.calls == 1
+        assert first.calls == [["alpha"], ["beta"]]
+        assert second.calls == []
+        assert provider.provider is first
+
+    asyncio.run(run())
+
+
+def test_api_embedding_provider_refreshes_model_info_cache_after_provider_change():
+    first = MetaEmbeddingProvider({"model": "Old/Embedding"})
+    second = MetaEmbeddingProvider({"model": "New/Embedding"})
+    context = ReplacingContext(first)
+    provider = APIEmbeddingProvider(
+        first,
+        "api_provider",
+        context=context,
+    )
+    provider._available = True
+
+    assert provider.get_model_info()["model_name"] == "Old_Embedding"
+
+    context.replacement = second
+
+    assert provider.get_model_info()["model_name"] == "New_Embedding"
+    assert provider.provider is second
 
 
 def test_api_embedding_provider_exposes_clean_model_name_from_meta():


### PR DESCRIPTION
## Summary

Fix stale AstrBot embedding provider references held by `APIEmbeddingProvider`.

`APIEmbeddingProvider` keeps the provider object captured during AngelMemory initialization. If AstrBot reloads that embedding provider later, the old provider can be terminated while AngelMemory still calls it during FAISS/query embedding. In practice this shows up as FAISS query vectorization warnings such as `Connection error`, while AstrBot's provider check succeeds because it uses the newly loaded provider instance.

This PR refreshes the provider reference from AstrBot context before embedding API calls and when building model info. Existing direct-provider usage remains unchanged when no context is available.

## Changes

- Store AstrBot context in `APIEmbeddingProvider` when created by `EmbeddingProviderFactory`.
- Refresh the current provider by `provider_id` before availability checks, batch embedding calls, and model info reads.
- Clear cached model info when the underlying provider instance changes.
- Add a regression test covering a closed/stale provider being replaced by the current context provider.
- Bump plugin version to `1.4.16`.

## Validation

- `python -m py_compile llm_memory/components/embedding_provider.py`
- `python -m pytest tests/test_embedding_provider.py` -> 5 passed
- `python -m pytest` with TEMP/TMP redirected into repo -> 65 passed, 2 failed, 1 skipped

The two full-suite failures appear unrelated to this PR:

- `tests/test_note_chunk_search.py::TestSearchEngine::test_rebuild_all` returns new indexed chunks for query `旧数据` after rebuild.
- `tests/test_session_memory_references.py::test_injection_hydrates_latest_memory_and_removes_missing_refs` fails because the test double `_DeepMind` lacks `plugin_context`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 提升嵌入提供程序的稳定性：运行期更新提供程序时，会自动刷新绑定引用，并在每次批次请求前确保使用有效的最新实例；同时会刷新模型信息缓存，避免使用过期元数据。

* **Tests**
  * 新增测试用例覆盖提供程序刷新、批次请求中引用一致性、以及模型信息缓存更新等场景。

* **Chores**
  * 插件版本升级至 1.4.16。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->