### PR TITLE
fix(embedding): 限制批量大小并处理 DashScope 限流

### DIFF
--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -631,7 +631,8 @@ class APIEmbeddingProvider(EmbeddingProvider):
         self._model_info = None
         self._available = None  # None表示未测试，True/False表示测试结果
         self._cache = EmbeddingCache(max_memory_mb=cache_size_mb)
-        self.batch_size = 64  # 程序启动时的批量大小，遇到413会自动减半并在本次生命周期内持久生效
+        # DashScope 等提供商限制单批不超过 10 条；使用较小默认值可避免 400。
+        self.batch_size = 10
         self._cache_enabled = True  # 缓存启用标志
         self._client_rebuild_lock = threading.RLock()
 
@@ -927,19 +928,33 @@ class APIEmbeddingProvider(EmbeddingProvider):
                     self._validate_embedding_count(result, texts)
                     return result
                 else:
-                    # 分批并发处理
-                    tasks = []
-                    for i in range(0, len(texts), batch_size):
-                        batch = texts[i : i + batch_size]
-                        task = provider.get_embeddings(batch)
-                        tasks.append(task)
+                    # 分批并发处理，但限制同时请求的批次数量，避免触发 429。
+                    sem = asyncio.Semaphore(1)
+                    batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
+
+                    async def run_batch(batch):
+                        async with sem:
+                            for attempt in range(4):
+                                try:
+                                    return await provider.get_embeddings(batch)
+                                except Exception as e:
+                                    if self._is_rate_limit_error(e) and attempt < 3:
+                                        delay = (2**attempt) + (attempt * 2)
+                                        self.logger.warning(
+                                            f"批量向量化遇到429限流，等待{delay}秒后重试 "
+                                            f"provider_id={self.provider_id} attempt={attempt + 1}"
+                                        )
+                                        await asyncio.sleep(delay)
+                                        continue
+                                    raise
+
+                    tasks = [run_batch(batch) for batch in batches]
 
                     # 并发执行所有批次
                     batch_results = await asyncio.gather(*tasks)
 
                     # 按顺序拼接结果
                     result = []
-                    batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
                     for batch, batch_embeddings in zip(batches, batch_results):
                         batch_embeddings = self._expand_aggregated_embedding(
                             batch_embeddings, batch
@@ -1019,7 +1034,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
     @staticmethod
     def _is_batch_too_large_error(e: Exception) -> bool:
-        """判断异常是否为批量大小超限（HTTP 413）"""
+        """判断异常是否为批量大小超限（HTTP 413 或 provider 明确报批量过大）"""
         # openai.APIStatusError 或类似异常
         if hasattr(e, "status_code") and e.status_code == 413:
             return True
@@ -1029,11 +1044,34 @@ class APIEmbeddingProvider(EmbeddingProvider):
                 hasattr(sub, "status_code") and sub.status_code == 413
                 for sub in e.exceptions
             )
-        # 兜底：检查错误消息中是否包含413相关关键词
+        # 兜底：检查错误消息中是否包含413或 provider 明确告知的批量上限错误。
         err_msg = str(e)
         if "413" in err_msg and "batch" in err_msg.lower():
             return True
+        lowered = err_msg.lower()
+        if "batch size" in lowered and (
+            "should not be larger" in lowered or "batch size is invalid" in lowered
+        ):
+            return True
         return False
+
+    @staticmethod
+    def _is_rate_limit_error(e: Exception) -> bool:
+        """判断异常是否为请求速率/配额超限（HTTP 429）。"""
+        if hasattr(e, "status_code") and e.status_code == 429:
+            return True
+        if hasattr(e, "exceptions"):
+            return any(
+                APIEmbeddingProvider._is_rate_limit_error(sub)
+                for sub in e.exceptions
+            )
+        err_msg = str(e).lower()
+        return (
+            "429" in err_msg
+            or "rate limit" in err_msg
+            or "throttling" in err_msg
+            or "ratequota" in err_msg
+        )
 
     @staticmethod
     def _meta_get(meta: Any, key: str, default: Any = None) -> Any:

--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -912,20 +912,88 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
         return full_embeddings
 
+    async def _get_embeddings_with_retry(
+        self,
+        provider: Any,
+        texts: List[str],
+        retry_stats: dict | None = None,
+    ) -> List[List[float]]:
+        """获取单个批次的向量嵌入，并在限流时进行指数退避重试。
+
+        Args:
+            provider: 提供 get_embeddings 方法的嵌入提供商实例。
+            texts: 当前批次的文本列表。
+            retry_stats: 可选的统计字典，用于聚合记录重试次数。
+
+        Returns:
+            当前批次的向量列表。
+
+        Raises:
+            Exception: 重试次数用尽后仍失败时抛出原始异常。
+        """
+        for attempt in range(4):
+            try:
+                return await provider.get_embeddings(texts)
+            except Exception as exc:
+                if self._is_rate_limit_error(exc) and attempt < 3:
+                    delay = (2**attempt) + (attempt * 2)
+                    if retry_stats is not None:
+                        retry_stats["retry_count"] += 1
+                    self.logger.debug(
+                        "批量向量化遇到429限流，等待%s秒后重试 "
+                        "provider_id=%s attempt=%s",
+                        delay,
+                        self.provider_id,
+                        attempt + 1,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+
+    def _log_retry_aggregate(self, retry_stats: dict, start_time: float) -> None:
+        """输出批量向量化过程中的聚合重试日志。
+
+        Args:
+            retry_stats: 包含 retry_count 和 text_count 的统计字典。
+            start_time: 开始时间戳，用于计算耗时毫秒。
+        """
+        if retry_stats["retry_count"] <= 0:
+            return
+        self.logger.warning(
+            "[睡眠维护] 任务名=批量向量化完成 provider_id=%s "
+            "重试次数=%s 文本数=%s 耗时毫秒=%s",
+            self.provider_id,
+            retry_stats["retry_count"],
+            retry_stats["text_count"],
+            int((time.time() - start_time) * 1000),
+        )
+
     async def _get_embeddings_with_batch(
         self, texts: List[str], batch_size: int
     ) -> List[List[float]]:
-        """使用指定批量大小并发获取向量嵌入，遇到413自动减半并在本次生命周期内持久化"""
+        """使用指定批量大小获取向量嵌入，遇到413自动减半并在本次生命周期内持久化。
 
+        Args:
+            texts: 需要向量化的文本列表。
+            batch_size: 单批最大文本数。
+
+        Returns:
+            全部文本的向量列表。
+        """
+        start_time = time.time()
+        retry_stats = {"retry_count": 0, "text_count": len(texts)}
         closed_client_retried = False
         while True:
             try:
                 provider = self._prepare_provider_for_request()
                 if batch_size >= len(texts):
-                    # 单批次处理
-                    result = await provider.get_embeddings(texts)
+                    # 单批次处理，同样走限流重试。
+                    result = await self._get_embeddings_with_retry(
+                        provider, texts, retry_stats
+                    )
                     result = self._expand_aggregated_embedding(result, texts)
                     self._validate_embedding_count(result, texts)
+                    self._log_retry_aggregate(retry_stats, start_time)
                     return result
                 else:
                     # 分批并发处理，但限制同时请求的批次数量，避免触发 429。
@@ -933,20 +1001,11 @@ class APIEmbeddingProvider(EmbeddingProvider):
                     batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
 
                     async def run_batch(batch):
+                        """串行执行单个批次并在限流时重试。"""
                         async with sem:
-                            for attempt in range(4):
-                                try:
-                                    return await provider.get_embeddings(batch)
-                                except Exception as e:
-                                    if self._is_rate_limit_error(e) and attempt < 3:
-                                        delay = (2**attempt) + (attempt * 2)
-                                        self.logger.warning(
-                                            f"批量向量化遇到429限流，等待{delay}秒后重试 "
-                                            f"provider_id={self.provider_id} attempt={attempt + 1}"
-                                        )
-                                        await asyncio.sleep(delay)
-                                        continue
-                                    raise
+                            return await self._get_embeddings_with_retry(
+                                provider, batch, retry_stats
+                            )
 
                     tasks = [run_batch(batch) for batch in batches]
 
@@ -962,6 +1021,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
                         self._validate_embedding_count(batch_embeddings, batch)
                         result.extend(batch_embeddings)
 
+                    self._log_retry_aggregate(retry_stats, start_time)
                     return result
             except Exception as e:
                 if self._is_batch_too_large_error(e) and batch_size > 1:

--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -936,7 +936,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
                 return await provider.get_embeddings(texts)
             except Exception as exc:
                 if self._is_rate_limit_error(exc) and attempt < 3:
-                    delay = (2**attempt) + (attempt * 2)
+                    delay = (1, 4, 12)[attempt]
                     if retry_stats is not None:
                         retry_stats["retry_count"] += 1
                     self.logger.debug(
@@ -996,25 +996,13 @@ class APIEmbeddingProvider(EmbeddingProvider):
                     self._log_retry_aggregate(retry_stats, start_time)
                     return result
                 else:
-                    # 分批并发处理，但限制同时请求的批次数量，避免触发 429。
-                    sem = asyncio.Semaphore(1)
+                    # 串行逐批处理，避免并发触发 429；某一批失败时不会遗留排队中的旧请求。
                     batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
-
-                    async def run_batch(batch):
-                        """串行执行单个批次并在限流时重试。"""
-                        async with sem:
-                            return await self._get_embeddings_with_retry(
-                                provider, batch, retry_stats
-                            )
-
-                    tasks = [run_batch(batch) for batch in batches]
-
-                    # 并发执行所有批次
-                    batch_results = await asyncio.gather(*tasks)
-
-                    # 按顺序拼接结果
                     result = []
-                    for batch, batch_embeddings in zip(batches, batch_results):
+                    for batch in batches:
+                        batch_embeddings = await self._get_embeddings_with_retry(
+                            provider, batch, retry_stats
+                        )
                         batch_embeddings = self._expand_aggregated_embedding(
                             batch_embeddings, batch
                         )

--- a/llm_memory/components/embedding_provider.py
+++ b/llm_memory/components/embedding_provider.py
@@ -671,6 +671,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
         return api_base
 
     def _provider_client_is_closed(self, provider) -> bool:
+        """判断上游 embedding provider 的 OpenAI client 是否已关闭。"""
         client = getattr(provider, "client", None)
         is_closed = getattr(client, "is_closed", None)
         if not callable(is_closed):
@@ -681,6 +682,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
             return False
 
     def _is_closed_client_error(self, error: Exception) -> bool:
+        """判断异常是否为上游 OpenAI client 已关闭导致的错误。"""
         message = str(error)
         if "Cannot send a request, as the client has been closed" in message:
             return True
@@ -762,6 +764,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
                 return False
 
     def _prepare_provider_for_request(self):
+        """刷新 provider 引用，并在 client 已关闭时尝试重建，返回可用实例。"""
         provider = self._refresh_provider_reference()
         if self._provider_client_is_closed(provider):
             self._rebuild_openai_embedding_client(provider)
@@ -1123,6 +1126,7 @@ class APIEmbeddingProvider(EmbeddingProvider):
 
     @staticmethod
     def _meta_get(meta: Any, key: str, default: Any = None) -> Any:
+        """从字典或对象中安全获取指定元数据键。"""
         if isinstance(meta, dict):
             return meta.get(key, default)
         return getattr(meta, key, default)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,5 @@ name: astrbot_plugin_angel_memory
 display_name: 天使之魂
 description: "赋予AI动态演化的人格、长期记忆与自主学习能力，将聊天工具升级为有生命感的AI伙伴。"
 author: kawayiYokami
-version: 1.6.1
+version: 1.6.2
 repo: https://github.com/kawayiYokami/astrbot_plugin_angel_memory

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -279,3 +279,32 @@ def test_api_embedding_provider_expands_aggregated_embedding():
         assert result == [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
 
     asyncio.run(run())
+
+
+def test_is_batch_too_large_error_detects_dashscope_batch_limit():
+    error = Exception(
+        "DashScope Embedding API request failed (HTTP 400): InvalidParameter - "
+        "InternalError.Algo.InvalidParameter: Value error, batch size is invalid, "
+        "it should not be larger than 10."
+    )
+
+    assert APIEmbeddingProvider._is_batch_too_large_error(error) is True
+
+
+def test_is_rate_limit_error_detects_http_429_and_throttling():
+    class _RateLimitError(Exception):
+        status_code = 429
+
+    assert APIEmbeddingProvider._is_rate_limit_error(_RateLimitError("rate limited")) is True
+    assert (
+        APIEmbeddingProvider._is_rate_limit_error(
+            Exception("Throttling.RateQuota - Requests rate limit exceeded")
+        )
+        is True
+    )
+    assert (
+        APIEmbeddingProvider._is_rate_limit_error(
+            Exception("some other invalid parameter")
+        )
+        is False
+    )

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -6,52 +6,75 @@ from llm_memory.components.embedding_provider import APIEmbeddingProvider
 
 
 class ShortEmbeddingProvider:
+    """返回固定长度向量的嵌入提供商。"""
+
     async def get_embeddings(self, texts):
+        """返回三组固定向量。"""
         return [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 
     async def get_embedding(self, text):
+        """返回固定向量。"""
         return [1.0, 0.0, 0.0]
 
 
 class AggregatingEmbeddingProvider:
+    """返回聚合单条向量的嵌入提供商。"""
+
     async def get_embeddings(self, texts):
+        """始终只返回一个聚合向量。"""
         return [[1.0, 2.0, 3.0]]
 
     async def get_embedding(self, text):
+        """返回固定聚合向量。"""
         return [1.0, 2.0, 3.0]
 
 
 class MetaEmbeddingProvider:
+    """携带 meta 信息的嵌入提供商。"""
+
     def __init__(self, meta):
+        """保存元数据。"""
         self._meta = meta
 
     def meta(self):
+        """返回元数据。"""
         return self._meta
 
     async def get_embeddings(self, texts):
+        """返回固定向量列表。"""
         return [[1.0, 0.0, 0.0] for _ in texts]
 
     async def get_embedding(self, text):
+        """返回固定向量。"""
         return [1.0, 0.0, 0.0]
 
 
 class ClosedEmbeddingProvider:
+    """模拟已关闭的嵌入提供商。"""
+
     async def get_embeddings(self, texts):
+        """始终抛出 provider 已关闭错误。"""
         raise RuntimeError("old provider is closed")
 
     async def get_embedding(self, text):
+        """始终抛出 provider 已关闭错误。"""
         raise RuntimeError("old provider is closed")
 
 
 class RecordingEmbeddingProvider:
+    """记录每次调用文本列表的嵌入提供商。"""
+
     def __init__(self):
+        """初始化调用记录列表。"""
         self.calls = []
 
     async def get_embeddings(self, texts):
+        """记录调用并返回固定向量。"""
         self.calls.append(list(texts))
         return [[1.0, 0.0, 0.0] for _ in texts]
 
     async def get_embedding(self, text):
+        """返回固定向量。"""
         return [1.0, 0.0, 0.0]
 
 
@@ -59,33 +82,44 @@ class RateLimitedEmbeddingProvider:
     """模拟首次请求触发 429、重试后成功的嵌入提供商。"""
 
     def __init__(self):
+        """初始化调用计数。"""
         self.calls = 0
 
     async def get_embeddings(self, texts):
+        """首次调用返回 429，后续返回固定向量。"""
         self.calls += 1
         if self.calls == 1:
             raise Exception("429 Throttling.RateQuota - rate limit exceeded")
         return [[1.0, 0.0, 0.0] for _ in texts]
 
     async def get_embedding(self, text):
+        """返回与 get_embeddings 相同的固定向量。"""
         return [1.0, 0.0, 0.0]
 
 
 class ReplacingContext:
+    """返回固定替换 provider 的上下文。"""
+
     def __init__(self, replacement):
+        """保存替换 provider。"""
         self.replacement = replacement
 
     def get_provider_by_id(self, provider_id):
+        """返回替换 provider。"""
         assert provider_id == "api_provider"
         return self.replacement
 
 
 class RotatingContext:
+    """按调用次数轮换替换 provider 的上下文。"""
+
     def __init__(self, replacements):
+        """保存替换 provider 列表。"""
         self.replacements = list(replacements)
         self.calls = 0
 
     def get_provider_by_id(self, provider_id):
+        """按顺序返回替换 provider。"""
         assert provider_id == "api_provider"
         index = min(self.calls, len(self.replacements) - 1)
         self.calls += 1
@@ -93,15 +127,22 @@ class RotatingContext:
 
 
 class FakeOpenAIClient:
+    """模拟 OpenAI client 的关闭状态。"""
+
     def __init__(self, closed=False):
+        """初始化关闭状态。"""
         self.closed = closed
 
     def is_closed(self):
+        """返回当前 client 是否已关闭。"""
         return self.closed
 
 
 class OpenAIStyleEmbeddingProvider:
+    """模拟 OpenAI 风格 embedding provider。"""
+
     def __init__(self):
+        """初始化配置、client 和调用计数。"""
         self.provider_config = {
             "id": "api_provider",
             "type": "openai_embedding",
@@ -116,23 +157,29 @@ class OpenAIStyleEmbeddingProvider:
         self.calls = 0
 
     async def get_embeddings(self, texts):
+        """client 已关闭时抛出异常，否则返回固定向量。"""
         self.calls += 1
         if self.client.is_closed():
             raise RuntimeError("Cannot send a request, as the client has been closed.")
         return [[1.0, 0.0, 0.0] for _ in texts]
 
     async def get_embedding(self, text):
+        """client 已关闭时抛出异常，否则返回固定向量。"""
         if self.client.is_closed():
             raise RuntimeError("Cannot send a request, as the client has been closed.")
         return [1.0, 0.0, 0.0]
 
 
 class FlakyClosedClientEmbeddingProvider(OpenAIStyleEmbeddingProvider):
+    """首次请求抛出 client 已关闭错误，后续成功的 embedding provider。"""
+
     def __init__(self):
+        """初始化 provider 并保持 client 未关闭。"""
         super().__init__()
         self.client = FakeOpenAIClient(closed=False)
 
     async def get_embeddings(self, texts):
+        """首次调用触发关闭错误，后续返回固定向量。"""
         self.calls += 1
         if self.calls == 1:
             raise RuntimeError("Cannot send a request, as the client has been closed.")
@@ -142,7 +189,9 @@ class FlakyClosedClientEmbeddingProvider(OpenAIStyleEmbeddingProvider):
 
 
 def test_api_embedding_provider_rejects_short_batch_results():
+    """嵌入提供商返回数量不足时，应抛出数量不匹配异常。"""
     async def run():
+        """运行异步测试逻辑。"""
         provider = APIEmbeddingProvider(ShortEmbeddingProvider(), "short_provider")
         provider._available = True
         provider._cache_enabled = False
@@ -158,7 +207,9 @@ def test_api_embedding_provider_rejects_short_batch_results():
 
 
 def test_api_embedding_provider_refreshes_provider_reference_before_batch_request():
+    """批量请求前应刷新 provider 引用。"""
     async def run():
+        """运行异步测试逻辑。"""
         replacement = MetaEmbeddingProvider({"model": "BAAI/bge-m3"})
         provider = APIEmbeddingProvider(
             ClosedEmbeddingProvider(),
@@ -177,7 +228,9 @@ def test_api_embedding_provider_refreshes_provider_reference_before_batch_reques
 
 
 def test_api_embedding_provider_uses_one_provider_reference_per_batch_attempt():
+    """每个批次尝试应使用同一个 provider 引用。"""
     async def run():
+        """运行异步测试逻辑。"""
         first = RecordingEmbeddingProvider()
         second = RecordingEmbeddingProvider()
         context = RotatingContext([first, second])
@@ -202,7 +255,9 @@ def test_api_embedding_provider_uses_one_provider_reference_per_batch_attempt():
 
 
 def test_api_embedding_provider_rebuilds_closed_openai_client_before_request():
+    """上游 client 已关闭时，应在请求前重建。"""
     async def run():
+        """运行异步测试逻辑。"""
         upstream = OpenAIStyleEmbeddingProvider()
         provider = APIEmbeddingProvider(upstream, "api_provider")
         provider._available = True
@@ -218,7 +273,9 @@ def test_api_embedding_provider_rebuilds_closed_openai_client_before_request():
 
 
 def test_api_embedding_provider_rebuilds_and_retries_after_closed_client_error():
+    """client 关闭错误后应重建并重试成功。"""
     async def run():
+        """运行异步测试逻辑。"""
         upstream = FlakyClosedClientEmbeddingProvider()
         provider = APIEmbeddingProvider(upstream, "api_provider")
         provider._available = True
@@ -234,6 +291,7 @@ def test_api_embedding_provider_rebuilds_and_retries_after_closed_client_error()
 
 
 def test_api_embedding_provider_detects_closed_client_from_exception_cause():
+    """应能从异常 cause 链中识别 client 已关闭错误。"""
     provider = APIEmbeddingProvider(MetaEmbeddingProvider({"model": "BAAI/bge-m3"}), "api_provider")
     outer = RuntimeError("Connection error.")
     outer.__cause__ = RuntimeError("Cannot send a request, as the client has been closed.")
@@ -242,6 +300,7 @@ def test_api_embedding_provider_detects_closed_client_from_exception_cause():
 
 
 def test_api_embedding_provider_refreshes_model_info_cache_after_provider_change():
+    """provider 引用变化后应刷新模型信息缓存。"""
     first = MetaEmbeddingProvider({"model": "Old/Embedding"})
     second = MetaEmbeddingProvider({"model": "New/Embedding"})
     context = ReplacingContext(first)
@@ -261,6 +320,7 @@ def test_api_embedding_provider_refreshes_model_info_cache_after_provider_change
 
 
 def test_api_embedding_provider_exposes_clean_model_name_from_meta():
+    """应从 meta 中提取并清洗模型名。"""
     provider = APIEmbeddingProvider(
         MetaEmbeddingProvider({"model": "BAAI/bge-m3"}),
         "api_provider",
@@ -273,6 +333,7 @@ def test_api_embedding_provider_exposes_clean_model_name_from_meta():
 
 
 def test_api_embedding_provider_exposes_clean_model_name_from_nested_meta():
+    """应从嵌套 meta 中提取并清洗模型名。"""
     provider = APIEmbeddingProvider(
         MetaEmbeddingProvider({"model_config": {"model": "Qwen/Qwen3-Embedding-8B"}}),
         "api_provider",
@@ -285,7 +346,9 @@ def test_api_embedding_provider_exposes_clean_model_name_from_nested_meta():
 
 
 def test_api_embedding_provider_expands_aggregated_embedding():
+    """聚合嵌入结果应扩展为批次内所有文本的向量。"""
     async def run():
+        """运行异步测试逻辑。"""
         provider = APIEmbeddingProvider(AggregatingEmbeddingProvider(), "aggregating_provider")
         provider._available = True
         provider._cache_enabled = False
@@ -332,6 +395,7 @@ def test_api_embedding_provider_retries_single_batch_on_rate_limit():
     """单批请求遇到 429 后应自动重试并成功返回。"""
 
     async def run():
+        """运行异步测试逻辑。"""
         provider = APIEmbeddingProvider(
             RateLimitedEmbeddingProvider(),
             "rate_limited_provider",

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -55,6 +55,22 @@ class RecordingEmbeddingProvider:
         return [1.0, 0.0, 0.0]
 
 
+class RateLimitedEmbeddingProvider:
+    """模拟首次请求触发 429、重试后成功的嵌入提供商。"""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def get_embeddings(self, texts):
+        self.calls += 1
+        if self.calls == 1:
+            raise Exception("429 Throttling.RateQuota - rate limit exceeded")
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+    async def get_embedding(self, text):
+        return [1.0, 0.0, 0.0]
+
+
 class ReplacingContext:
     def __init__(self, replacement):
         self.replacement = replacement
@@ -282,6 +298,7 @@ def test_api_embedding_provider_expands_aggregated_embedding():
 
 
 def test_is_batch_too_large_error_detects_dashscope_batch_limit():
+    """应能识别 DashScope 返回的批量大小超限错误。"""
     error = Exception(
         "DashScope Embedding API request failed (HTTP 400): InvalidParameter - "
         "InternalError.Algo.InvalidParameter: Value error, batch size is invalid, "
@@ -292,6 +309,7 @@ def test_is_batch_too_large_error_detects_dashscope_batch_limit():
 
 
 def test_is_rate_limit_error_detects_http_429_and_throttling():
+    """应能识别 HTTP 429 与限流文本错误。"""
     class _RateLimitError(Exception):
         status_code = 429
 
@@ -308,3 +326,22 @@ def test_is_rate_limit_error_detects_http_429_and_throttling():
         )
         is False
     )
+
+
+def test_api_embedding_provider_retries_single_batch_on_rate_limit():
+    """单批请求遇到 429 后应自动重试并成功返回。"""
+
+    async def run():
+        provider = APIEmbeddingProvider(
+            RateLimitedEmbeddingProvider(),
+            "rate_limited_provider",
+        )
+        provider._available = True
+        provider._cache_enabled = False
+        provider.batch_size = 100
+
+        result = await provider.embed_documents(["alpha", "beta"])
+
+        assert result == [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+
+    asyncio.run(run())


### PR DESCRIPTION
## 问题

使用 DashScope embedding 同步大规模记忆时，会出现两类失败：

1. `HTTP 400 InvalidParameter: batch size is invalid, it should not be larger than 10`
   - 插件默认 `batch_size = 64`，单批超过 DashScope 限制。

2. `HTTP 429 Throttling.RateQuota`
   - 大批量同步时所有批次同时并发请求，触发限流。

## 修改

- `llm_memory/components/embedding_provider.py`
  - 默认 `batch_size` 从 `64` 改为 `10`。
  - `_is_batch_too_large_error()` 增加对 DashScope 批量上限 400 错误的识别。
  - 新增 `_is_rate_limit_error()`，识别 HTTP 429 / `Throttling.RateQuota` / `rate limit`。
  - 分批请求改为**串行**（Semaphore=1），避免并发把 API 限流打爆。
  - 每个批次遇到 429 时自动退避重试（1s、4s、12s，最多 4 次）。

- `tests/test_embedding_provider.py`
  - 新增批量上限错误识别测试。
  - 新增 429 限流错误识别测试。

- `metadata.yaml`
  - 版本号 `1.6.1` → `1.6.2`。

## 验证

- `tests/test_embedding_provider.py`：12 passed。
- 本地 DashScope 记忆同步测试通过，不再出现 400/429 导致同步失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 嵌入服务默认批量大小调整为 10，提升请求稳定性。
  * 请求改为串行处理，遇到限流、配额不足或 HTTP 429 时，自动进行最多 4 次指数退避重试。
  * 改进批量超限及限流错误识别，提供更可靠的错误提示与处理。

* **版本**
  * 插件版本更新至 1.6.2。

* **测试**
  * 新增批量限制、限流、HTTP 429 及普通参数错误的识别测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->