### PR TITLE
feat: add rerank failover and atomic daily backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 | `provider_id` | "" | 记忆整理LLM提供商ID（建议有思考能力的模型） |
 | `retrieval.embedding_provider_id` | "" | 嵌入模型提供商ID（可选，实测提升有限） |
 | `retrieval.rerank_provider_id` | "" | 重排提供商ID（推荐，效果提升明显） |
+| `retrieval.rerank_fallback_provider_ids` | `[]` | 主重排失败时依序尝试的备用 Provider；支持熔断与本地负载限制 |
 | `conversation_scope_map` | "{}" | 记忆分类映射（先按人格名匹配，再按会话ID匹配，未命中为public） |
 | `memory_behavior.min_message_length` | 5 | 触发记忆处理的最小消息长度 |
 | `memory_behavior.sleep_interval` | 3600 | 记忆巩固间隔（秒） |

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,6 +23,50 @@
         "default": "",
         "hint": "推荐使用，检索效果提升明显；不依赖嵌入模型，BM25 候选也可以直接重排。留空则自动尝试复用 provider_id，若不可用则降级为非重排策略。"
       },
+      "rerank_fallback_provider_ids": {
+        "type": "list",
+        "description": "检索重排备用提供商ID",
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "hint": "主重排服务失败或返回空结果时按顺序回退；不会改变主检索模型。"
+      },
+      "rerank_primary_timeout": {
+        "type": "float",
+        "description": "OpenAI 兼容重排端点超时（秒）",
+        "default": 8.0,
+        "hint": "仅用于把现有 OpenAI 兼容 Provider 适配到 /rerank 的请求，范围 2-60 秒。"
+      },
+      "rerank_failure_threshold": {
+        "type": "int",
+        "description": "重排熔断失败次数",
+        "default": 3,
+        "hint": "同一主重排连续失败达到此次数后，在冷却期内暂时跳过。"
+      },
+      "rerank_cooldown_seconds": {
+        "type": "float",
+        "description": "重排熔断冷却时间（秒）",
+        "default": 60.0
+      },
+      "rerank_fallback_max_documents": {
+        "type": "int",
+        "description": "备用重排最大候选数",
+        "default": 0,
+        "hint": "仅限制第二个及后续备用重排服务；0 表示继续沿用全局 rerank_max_docs。小显存本地服务可设为 24。"
+      },
+      "rerank_fallback_max_document_chars": {
+        "type": "int",
+        "description": "备用重排单篇最大字符数",
+        "default": 0,
+        "hint": "仅限制第二个及后续备用重排服务；超长片段会保留开头和结尾，0 表示不额外限制。"
+      },
+      "rerank_fallback_retry_document_chars": {
+        "type": "int",
+        "description": "备用重排溢出重试字符数",
+        "default": 0,
+        "hint": "备用服务因物理批次不足返回 500 时，缩短单篇内容并自动重试一次；0 表示不重试。"
+      },
       "enable_local_embedding": {
         "type": "bool",
         "description": "启用本地嵌入模型支持",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -53,13 +53,13 @@
         "type": "int",
         "description": "备用重排最大候选数",
         "default": 0,
-        "hint": "仅限制第二个及后续备用重排服务；0 表示继续沿用全局 rerank_max_docs。小显存本地服务可设为 24。"
+        "hint": "仅限制备用重排服务（不影响主重排）；0 表示继续沿用全局 rerank_max_docs。小显存本地服务可设为 24。"
       },
       "rerank_fallback_max_document_chars": {
         "type": "int",
         "description": "备用重排单篇最大字符数",
         "default": 0,
-        "hint": "仅限制第二个及后续备用重排服务；超长片段会保留开头和结尾，0 表示不额外限制。"
+        "hint": "仅限制备用重排服务（不影响主重排）；超长片段会保留开头和结尾，0 表示不额外限制。"
       },
       "rerank_fallback_retry_document_chars": {
         "type": "int",

--- a/core/component_factory.py
+++ b/core/component_factory.py
@@ -30,6 +30,10 @@ from ..llm_memory.service.memory_decay_policy import (
 from ..llm_memory.service.note_service import NoteService
 from .memory_runtime import SimpleMemoryRuntime, VectorMemoryRuntime
 from .deepmind import DeepMind
+from .rerank_failover import (
+    CredentialBackedOpenAIRerankProvider,
+    FailoverRerankProvider,
+)
 
 
 class ComponentFactory:
@@ -421,44 +425,109 @@ class ComponentFactory:
         """
         try:
             rerank_provider_id = self.plugin_context.get_rerank_provider_id()
+            fallback_ids = self.plugin_context.get_rerank_fallback_provider_ids()
             llm_provider_id = self.plugin_context.get_llm_provider_id()
-            candidate_ids = [
-                pid
-                for pid in [
-                    rerank_provider_id,
-                    llm_provider_id,
-                ]
-                if pid
-            ]
+            candidate_ids = list(
+                dict.fromkeys(
+                    pid
+                    for pid in [
+                        rerank_provider_id,
+                        *fallback_ids,
+                        llm_provider_id,
+                    ]
+                    if pid
+                )
+            )
+            retrieval = self.plugin_context.get_all_config().get("retrieval", {}) or {}
+            if not isinstance(retrieval, dict):
+                retrieval = {}
 
-            # 先按显式 ID 查找
+            def bounded_number(key, default, minimum, maximum, cast):
+                try:
+                    value = cast(retrieval.get(key, default))
+                except (TypeError, ValueError):
+                    value = cast(default)
+                return max(minimum, min(maximum, value))
+
+            remote_timeout = bounded_number(
+                "rerank_primary_timeout", 8.0, 2.0, 60.0, float
+            )
+            resolved: list[tuple[str, Any]] = []
+
+            # 显式链中的专用 rerank Provider 优先；普通 OpenAI-compatible
+            # Provider 仅在模型名明确为 reranker 时适配其 /rerank 端点。
             for pid in candidate_ids:
+                provider = None
                 if hasattr(self.context, "get_rerank_provider_by_id"):
                     provider = self.context.get_rerank_provider_by_id(pid)
                     if provider and hasattr(provider, "rerank"):
                         self.logger.info(f"✅ 使用上游重排提供商: {pid}")
-                        return provider
+                        resolved.append((pid, provider))
+                        continue
 
-                if hasattr(self.context, "get_provider_by_id"):
-                    provider = self.context.get_provider_by_id(pid)
-                    if provider and hasattr(provider, "rerank"):
-                        self.logger.info(f"✅ 使用上游可重排提供商: {pid}")
-                        return provider
+                if not hasattr(self.context, "get_provider_by_id"):
+                    continue
+                provider = self.context.get_provider_by_id(pid)
+                if provider and hasattr(provider, "rerank"):
+                    self.logger.info(f"✅ 使用上游可重排提供商: {pid}")
+                    resolved.append((pid, provider))
+                    continue
 
-            # 再从列表中兜底挑选
+                model_getter = getattr(provider, "get_model", None)
+                model = model_getter() if callable(model_getter) else ""
+                if provider and "reranker" in str(model).lower():
+                    resolved.append(
+                        (
+                            pid,
+                            CredentialBackedOpenAIRerankProvider(
+                                pid,
+                                provider,
+                                timeout=remote_timeout,
+                            ),
+                        )
+                    )
+                    self.logger.info(f"✅ 使用 OpenAI 兼容重排端点: {pid}/rerank")
+
+            if resolved:
+                if len(resolved) == 1:
+                    return resolved[0][1]
+                self.logger.info(
+                    "✅ 启用重排故障转移链: %s",
+                    " -> ".join(provider_id for provider_id, _ in resolved),
+                )
+                return FailoverRerankProvider(
+                    resolved,
+                    failure_threshold=bounded_number(
+                        "rerank_failure_threshold", 3, 1, 20, int
+                    ),
+                    cooldown_seconds=bounded_number(
+                        "rerank_cooldown_seconds", 60.0, 5.0, 3600.0, float
+                    ),
+                    fallback_max_documents=bounded_number(
+                        "rerank_fallback_max_documents", 0, 0, 200, int
+                    ),
+                    fallback_max_document_chars=bounded_number(
+                        "rerank_fallback_max_document_chars", 0, 0, 100000, int
+                    ),
+                    fallback_retry_document_chars=bounded_number(
+                        "rerank_fallback_retry_document_chars", 0, 0, 100000, int
+                    ),
+                )
+
+            # 未配置显式链时再从 AstrBot 的专用列表自动选择单一 Provider。
             if hasattr(self.context, "get_all_rerank_providers"):
                 providers = self.context.get_all_rerank_providers() or []
-                for p in providers:
-                    if hasattr(p, "rerank"):
+                for provider in providers:
+                    if hasattr(provider, "rerank"):
                         self.logger.info("✅ 使用上游重排提供商: <auto>")
-                        return p
+                        return provider
 
             if hasattr(self.context, "get_all_providers"):
                 providers = self.context.get_all_providers() or []
-                for p in providers:
-                    if hasattr(p, "rerank"):
+                for provider in providers:
+                    if hasattr(provider, "rerank"):
                         self.logger.info("✅ 使用上游可重排提供商: <auto>")
-                        return p
+                        return provider
 
             self.logger.info("ℹ️ 未启用记忆二阶段重排，当前使用 FAISS 向量相似度排序结果")
             return None

--- a/core/plugin_context.py
+++ b/core/plugin_context.py
@@ -159,6 +159,24 @@ class PluginContext:
                 return value
         return str(self.config.get("rerank_provider_id", "") or "").strip()
 
+    def get_rerank_fallback_provider_ids(self) -> list[str]:
+        """获取检索重排备用提供商ID并去重。"""
+        retrieval = self.config.get("retrieval", {}) or {}
+        value = (
+            retrieval.get("rerank_fallback_provider_ids", [])
+            if isinstance(retrieval, dict)
+            else []
+        )
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list):
+            return []
+        return list(
+            dict.fromkeys(
+                str(item).strip() for item in value if str(item).strip()
+            )
+        )
+
     def get_embedding_batch_size(self) -> int:
         """获取向量请求批次大小（兼容顶层旧字段，仅下限 1，不设上限）。"""
         retrieval = self.config.get("retrieval", {}) or {}

--- a/core/rerank_failover.py
+++ b/core/rerank_failover.py
@@ -1,0 +1,298 @@
+"""Rerank provider adapters and failover orchestration for AngelMemory."""
+
+from __future__ import annotations
+
+import inspect
+import time
+from typing import Any
+
+import aiohttp
+
+try:
+    from astrbot.api import logger
+except ImportError:
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+
+def _limit_fallback_documents(
+    documents: list[str],
+    *,
+    max_documents: int,
+    max_document_chars: int,
+) -> list[str]:
+    """Bound a local fallback workload while keeping useful context at both ends."""
+    limited = documents[:max_documents] if max_documents > 0 else documents
+    if max_document_chars <= 0:
+        return limited
+
+    marker = "\n[…]\n"
+    bounded: list[str] = []
+    for document in limited:
+        text = str(document or "")
+        if len(text) <= max_document_chars:
+            bounded.append(text)
+            continue
+
+        content_chars = max(1, max_document_chars - len(marker))
+        head_chars = max(1, content_chars * 3 // 4)
+        tail_chars = max(0, content_chars - head_chars)
+        tail = text[-tail_chars:] if tail_chars else ""
+        bounded.append(f"{text[:head_chars]}{marker}{tail}")
+    return bounded
+
+
+async def _call_provider(
+    provider: Any,
+    *,
+    query: str,
+    documents: list[str],
+    top_n: int | None,
+) -> list[dict[str, Any]]:
+    rerank_method = provider.rerank
+    call_kwargs: dict[str, Any] = {
+        "query": query,
+        "documents": documents,
+    }
+    if top_n is not None:
+        try:
+            parameters = inspect.signature(rerank_method).parameters.values()
+            accepts_top_n = any(
+                parameter.name == "top_n"
+                or parameter.kind == inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            )
+        except (TypeError, ValueError):
+            accepts_top_n = True
+        if accepts_top_n:
+            call_kwargs["top_n"] = int(top_n)
+
+    result = rerank_method(**call_kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+    normalized = _normalize_results(result)
+    if not normalized:
+        raise RuntimeError("Rerank Provider 返回空结果")
+    if top_n is not None:
+        return normalized[: max(0, int(top_n))]
+    return normalized
+
+
+def _should_retry_with_shorter_documents(exc: Exception) -> bool:
+    """Retry local server errors that may be llama.cpp physical-batch overflow."""
+    status = getattr(exc, "status", None)
+    message = str(exc).lower()
+    return status == 500 or "too large to process" in message or "physical batch" in message
+
+
+def _normalize_results(response: Any) -> list[dict[str, Any]]:
+    """Normalize AstrBot objects and OpenAI-compatible JSON to one result shape."""
+    if isinstance(response, dict):
+        items = response.get("results")
+        if items is None:
+            data = response.get("data")
+            if isinstance(data, list):
+                items = data
+            elif isinstance(data, dict):
+                items = data.get("results") or data.get("items")
+    else:
+        items = response
+    if not isinstance(items, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            try:
+                index = int(item.get("index", -1))
+                score = float(
+                    item.get("relevance_score", item.get("score", 0.0)) or 0.0
+                )
+            except (TypeError, ValueError):
+                continue
+        else:
+            try:
+                index = int(getattr(item, "index"))
+                score = float(
+                    getattr(item, "relevance_score", getattr(item, "score", 0.0))
+                    or 0.0
+                )
+            except (AttributeError, TypeError, ValueError):
+                continue
+        if index < 0:
+            continue
+        normalized.append(
+            {
+                "index": index,
+                "score": score,
+                "relevance_score": score,
+            }
+        )
+    return normalized
+
+
+class CredentialBackedOpenAIRerankProvider:
+    """Use an existing OpenAI chat provider's URL and rotating credentials for /rerank."""
+
+    def __init__(self, provider_id: str, credential_provider: Any, timeout: float = 8.0):
+        self.provider_id = provider_id
+        self.credential_provider = credential_provider
+        self.timeout = max(2.0, min(60.0, float(timeout)))
+
+    def _base_url(self) -> str:
+        client = getattr(self.credential_provider, "client", None)
+        base_url = str(getattr(client, "base_url", "") or "").rstrip("/")
+        if not base_url:
+            raise RuntimeError(f"Rerank Provider {self.provider_id} 缺少 API Base URL")
+        return base_url
+
+    def _api_key(self) -> str:
+        getter = getattr(self.credential_provider, "get_current_key", None)
+        key = getter() if callable(getter) else ""
+        if not key:
+            raise RuntimeError(f"Rerank Provider {self.provider_id} 缺少 API Key")
+        return str(key)
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_n: int | None = None,
+    ) -> list[dict[str, Any]]:
+        if not documents:
+            return []
+        model_getter = getattr(self.credential_provider, "get_model", None)
+        model = model_getter() if callable(model_getter) else ""
+        payload: dict[str, Any] = {
+            "model": model,
+            "query": query,
+            "documents": documents,
+        }
+        if top_n is not None:
+            payload["top_n"] = int(top_n)
+
+        provider_config = getattr(self.credential_provider, "provider_config", {}) or {}
+        proxy = str(provider_config.get("proxy") or "").strip() or None
+        headers = {
+            "Authorization": f"Bearer {self._api_key()}",
+            "Content-Type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{self._base_url()}/rerank",
+                json=payload,
+                headers=headers,
+                proxy=proxy,
+            ) as response:
+                response.raise_for_status()
+                return _normalize_results(await response.json())
+
+
+class FailoverRerankProvider:
+    """Try providers in order and temporarily circuit-break repeatedly failing primaries."""
+
+    def __init__(
+        self,
+        providers: list[tuple[str, Any]],
+        *,
+        failure_threshold: int = 3,
+        cooldown_seconds: float = 60.0,
+        fallback_max_documents: int = 0,
+        fallback_max_document_chars: int = 0,
+        fallback_retry_document_chars: int = 0,
+    ):
+        self.providers = providers
+        self.failure_threshold = max(1, int(failure_threshold))
+        self.cooldown_seconds = max(5.0, float(cooldown_seconds))
+        self.fallback_max_documents = max(0, int(fallback_max_documents))
+        self.fallback_max_document_chars = max(0, int(fallback_max_document_chars))
+        self.fallback_retry_document_chars = max(
+            0, int(fallback_retry_document_chars)
+        )
+        self._failure_counts: dict[str, int] = {}
+        self._cooldown_until: dict[str, float] = {}
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_n: int | None = None,
+    ) -> list[dict[str, Any]]:
+        last_error: Exception | None = None
+        now = time.monotonic()
+        for index, (provider_id, provider) in enumerate(self.providers):
+            is_last = index == len(self.providers) - 1
+            if not is_last and self._cooldown_until.get(provider_id, 0.0) > now:
+                continue
+            try:
+                provider_documents = documents
+                provider_top_n = top_n
+                if index > 0:
+                    provider_documents = _limit_fallback_documents(
+                        documents,
+                        max_documents=self.fallback_max_documents,
+                        max_document_chars=self.fallback_max_document_chars,
+                    )
+                    if provider_top_n is not None:
+                        provider_top_n = min(
+                            int(provider_top_n), len(provider_documents)
+                        )
+                try:
+                    normalized = await _call_provider(
+                        provider,
+                        query=query,
+                        documents=provider_documents,
+                        top_n=provider_top_n,
+                    )
+                except Exception as first_exc:
+                    retry_chars = self.fallback_retry_document_chars
+                    can_retry = (
+                        index > 0
+                        and retry_chars > 0
+                        and any(len(str(doc or "")) > retry_chars for doc in provider_documents)
+                        and _should_retry_with_shorter_documents(first_exc)
+                    )
+                    if not can_retry:
+                        raise
+                    retry_documents = _limit_fallback_documents(
+                        provider_documents,
+                        max_documents=0,
+                        max_document_chars=retry_chars,
+                    )
+                    logger.warning(
+                        "Rerank Provider %s 输入超过本地处理能力，单篇缩短至 %s 字后重试",
+                        provider_id,
+                        retry_chars,
+                    )
+                    normalized = await _call_provider(
+                        provider,
+                        query=query,
+                        documents=retry_documents,
+                        top_n=provider_top_n,
+                    )
+                self._failure_counts[provider_id] = 0
+                self._cooldown_until.pop(provider_id, None)
+                return normalized
+            except Exception as exc:
+                last_error = exc
+                failures = self._failure_counts.get(provider_id, 0) + 1
+                self._failure_counts[provider_id] = failures
+                if not is_last and failures >= self.failure_threshold:
+                    self._cooldown_until[provider_id] = (
+                        time.monotonic() + self.cooldown_seconds
+                    )
+                    self._failure_counts[provider_id] = 0
+                next_provider = (
+                    self.providers[index + 1][0] if not is_last else "BM25/向量排序"
+                )
+                logger.warning(
+                    "Rerank Provider %s 失败，回退到 %s: %s",
+                    provider_id,
+                    next_provider,
+                    exc,
+                )
+        if last_error:
+            logger.warning("全部 Rerank Provider 均不可用: %s", last_error)
+        return []

--- a/core/rerank_failover.py
+++ b/core/rerank_failover.py
@@ -75,7 +75,8 @@ async def _call_provider(
     if not normalized:
         raise RuntimeError("Rerank Provider 返回空结果")
     if top_n is not None:
-        return normalized[: max(0, int(top_n))]
+        ranked = sorted(normalized, key=lambda item: item["score"], reverse=True)
+        return ranked[: max(0, int(top_n))]
     return normalized
 
 
@@ -83,7 +84,11 @@ def _should_retry_with_shorter_documents(exc: Exception) -> bool:
     """Retry local server errors that may be llama.cpp physical-batch overflow."""
     status = getattr(exc, "status", None)
     message = str(exc).lower()
-    return status == 500 or "too large to process" in message or "physical batch" in message
+    return (
+        status == 500
+        or "too large to process" in message
+        or "physical batch" in message
+    )
 
 
 def _normalize_results(response: Any) -> list[dict[str, Any]]:
@@ -226,8 +231,9 @@ class FailoverRerankProvider:
             is_last = index == len(self.providers) - 1
             if not is_last and self._cooldown_until.get(provider_id, 0.0) > now:
                 continue
+            attempt_started = time.monotonic()
+            provider_documents = documents
             try:
-                provider_documents = documents
                 provider_top_n = top_n
                 if index > 0:
                     provider_documents = _limit_fallback_documents(
@@ -251,7 +257,10 @@ class FailoverRerankProvider:
                     can_retry = (
                         index > 0
                         and retry_chars > 0
-                        and any(len(str(doc or "")) > retry_chars for doc in provider_documents)
+                        and any(
+                            len(str(doc or "")) > retry_chars
+                            for doc in provider_documents
+                        )
                         and _should_retry_with_shorter_documents(first_exc)
                     )
                     if not can_retry:
@@ -262,9 +271,13 @@ class FailoverRerankProvider:
                         max_document_chars=retry_chars,
                     )
                     logger.warning(
-                        "Rerank Provider %s 输入超过本地处理能力，单篇缩短至 %s 字后重试",
+                        "[重排] 重试 任务名=候选重排 Provider=%s "
+                        "触发条件=输入超过本地处理能力 单篇字符上限=%s "
+                        "候选数=%s 耗时毫秒=%s",
                         provider_id,
                         retry_chars,
+                        len(retry_documents),
+                        int((time.monotonic() - attempt_started) * 1000),
                     )
                     normalized = await _call_provider(
                         provider,
@@ -288,11 +301,25 @@ class FailoverRerankProvider:
                     self.providers[index + 1][0] if not is_last else "BM25/向量排序"
                 )
                 logger.warning(
-                    "Rerank Provider %s 失败，回退到 %s: %s",
+                    "[重排] 失败 任务名=候选重排 Provider=%s 回退目标=%s "
+                    "候选数=%s 耗时毫秒=%s 异常=%s",
                     provider_id,
                     next_provider,
+                    len(provider_documents),
+                    int((time.monotonic() - attempt_started) * 1000),
                     exc,
+                    exc_info=True,
                 )
         if last_error:
-            logger.warning("全部 Rerank Provider 均不可用: %s", last_error)
+            logger.error(
+                "[重排] 失败 任务名=重排故障转移 候选总数=%s "
+                "处理=降级为BM25/向量排序 异常=%s",
+                len(self.providers),
+                last_error,
+                exc_info=(
+                    type(last_error),
+                    last_error,
+                    last_error.__traceback__,
+                ),
+            )
         return []

--- a/core/services/sleep_maintenance_service.py
+++ b/core/services/sleep_maintenance_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict
@@ -293,12 +295,53 @@ class SleepMaintenanceService:
 
         center_dir = plugin_context.get_memory_center_dir()
         backup_dir = Path(center_dir) / "backups"
-        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            backup_dir.chmod(0o700)
+        except OSError:
+            # Windows and some mounted filesystems do not expose POSIX modes.
+            pass
         backup_file = backup_dir / f"memory_backup_{today}.json"
 
         snapshot = await memory_sql_manager.export_backup_snapshot()
-        with backup_file.open("w", encoding="utf-8") as f:
-            json.dump(snapshot, f, ensure_ascii=False, indent=2)
+        temp_fd, temp_name = tempfile.mkstemp(
+            prefix=f".{backup_file.name}.",
+            suffix=".tmp",
+            dir=backup_dir,
+        )
+        try:
+            try:
+                os.fchmod(temp_fd, 0o600)
+            except (AttributeError, OSError):
+                pass
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as file_handle:
+                temp_fd = -1
+                json.dump(snapshot, file_handle, ensure_ascii=False, indent=2)
+                file_handle.flush()
+                os.fsync(file_handle.fileno())
+            os.replace(temp_name, backup_file)
+            try:
+                backup_file.chmod(0o600)
+            except OSError:
+                pass
+
+            # Persist the rename on filesystems that support directory fsync.
+            directory_flags = os.O_RDONLY
+            directory_flags |= getattr(os, "O_DIRECTORY", 0)
+            directory_flags |= getattr(os, "O_CLOEXEC", 0)
+            try:
+                directory_fd = os.open(backup_dir, directory_flags)
+            except OSError:
+                directory_fd = -1
+            if directory_fd >= 0:
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+        finally:
+            if temp_fd >= 0:
+                os.close(temp_fd)
+            Path(temp_name).unlink(missing_ok=True)
 
         backup_files = sorted(backup_dir.glob("memory_backup_*.json"))
         while len(backup_files) > 3:

--- a/core/services/sleep_maintenance_service.py
+++ b/core/services/sleep_maintenance_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import errno
 import json
 import os
+import stat
 import tempfile
 import time
 from pathlib import Path
@@ -10,6 +12,77 @@ from typing import Any, Dict
 from ..migrations.memory_scope_migration import MemoryScopeMigration
 from .simple_memory_backup_service import SimpleMemoryBackupService
 from .memory_vector_sync_service import MemoryVectorSyncService
+
+
+_UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS = {
+    value
+    for value in (
+        errno.EINVAL,
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if isinstance(value, int)
+}
+
+
+def _secure_private_directory(path: Path) -> None:
+    """Create a private backup directory and verify POSIX permissions."""
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "posix":
+        return
+    path.chmod(0o700)
+    actual_mode = stat.S_IMODE(path.stat().st_mode)
+    if actual_mode != 0o700:
+        raise PermissionError(
+            f"无法将备份目录权限收紧为 0700（实际 {actual_mode:04o}）: {path}"
+        )
+
+
+def _secure_private_file(path: Path) -> None:
+    """Verify that the published backup is private on POSIX systems."""
+    if os.name != "posix":
+        return
+    path.chmod(0o600)
+    actual_mode = stat.S_IMODE(path.stat().st_mode)
+    if actual_mode != 0o600:
+        path.unlink(missing_ok=True)
+        raise PermissionError(
+            f"无法将备份文件权限收紧为 0600（实际 {actual_mode:04o}）: {path}"
+        )
+
+
+def _fsync_directory(path: Path, logger) -> None:
+    """Persist a rename when supported; propagate genuine I/O failures."""
+    if os.name != "posix":
+        return
+
+    directory_flags = os.O_RDONLY
+    directory_flags |= getattr(os, "O_DIRECTORY", 0)
+    directory_flags |= getattr(os, "O_CLOEXEC", 0)
+    try:
+        directory_fd = os.open(path, directory_flags)
+    except OSError as exc:
+        if exc.errno in _UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS:
+            logger.warning(
+                "[睡眠维护] 每日 JSON 备份：目录 fsync 不受支持，已保留原子替换 errno=%s",
+                exc.errno,
+            )
+            return
+        raise
+
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError as exc:
+            if exc.errno in _UNSUPPORTED_DIRECTORY_FSYNC_ERRNOS:
+                logger.warning(
+                    "[睡眠维护] 每日 JSON 备份：目录 fsync 不受支持，已保留原子替换 errno=%s",
+                    exc.errno,
+                )
+                return
+            raise
+    finally:
+        os.close(directory_fd)
 
 
 class SleepMaintenanceService:
@@ -295,12 +368,7 @@ class SleepMaintenanceService:
 
         center_dir = plugin_context.get_memory_center_dir()
         backup_dir = Path(center_dir) / "backups"
-        backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        try:
-            backup_dir.chmod(0o700)
-        except OSError:
-            # Windows and some mounted filesystems do not expose POSIX modes.
-            pass
+        _secure_private_directory(backup_dir)
         backup_file = backup_dir / f"memory_backup_{today}.json"
 
         snapshot = await memory_sql_manager.export_backup_snapshot()
@@ -310,34 +378,16 @@ class SleepMaintenanceService:
             dir=backup_dir,
         )
         try:
-            try:
+            if os.name == "posix":
                 os.fchmod(temp_fd, 0o600)
-            except (AttributeError, OSError):
-                pass
             with os.fdopen(temp_fd, "w", encoding="utf-8") as file_handle:
                 temp_fd = -1
                 json.dump(snapshot, file_handle, ensure_ascii=False, indent=2)
                 file_handle.flush()
                 os.fsync(file_handle.fileno())
             os.replace(temp_name, backup_file)
-            try:
-                backup_file.chmod(0o600)
-            except OSError:
-                pass
-
-            # Persist the rename on filesystems that support directory fsync.
-            directory_flags = os.O_RDONLY
-            directory_flags |= getattr(os, "O_DIRECTORY", 0)
-            directory_flags |= getattr(os, "O_CLOEXEC", 0)
-            try:
-                directory_fd = os.open(backup_dir, directory_flags)
-            except OSError:
-                directory_fd = -1
-            if directory_fd >= 0:
-                try:
-                    os.fsync(directory_fd)
-                finally:
-                    os.close(directory_fd)
+            _secure_private_file(backup_file)
+            _fsync_directory(backup_dir, deepmind.logger)
         finally:
             if temp_fd >= 0:
                 os.close(temp_fd)
@@ -349,7 +399,9 @@ class SleepMaintenanceService:
             try:
                 stale.unlink(missing_ok=True)
             except Exception as e:
-                deepmind.logger.warning(f"[睡眠维护] 删除旧备份失败 文件={stale.name} 异常={e}")
+                deepmind.logger.warning(
+                    f"[睡眠维护] 删除旧备份失败 文件={stale.name} 异常={e}"
+                )
 
         state["daily_json_backup_last_day"] = today
         deepmind.logger.info(

--- a/tests/test_atomic_daily_backup.py
+++ b/tests/test_atomic_daily_backup.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(PLUGIN_ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT.parent))
+
+from astrbot_plugin_angel_memory.core.services.sleep_maintenance_service import (
+    SleepMaintenanceService,
+)
+
+
+class _Logger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+
+class _MemoryManager:
+    async def export_backup_snapshot(self):
+        return {"records": [{"id": "memory-1"}], "global_tags": []}
+
+
+class _PluginContext:
+    def __init__(self, root):
+        self.root = root
+        self.manager = _MemoryManager()
+
+    def get_memory_center_dir(self):
+        return self.root
+
+    def get_component(self, name):
+        return self.manager if name == "memory_sql_manager" else None
+
+
+class _DeepMind:
+    def __init__(self, root):
+        self.plugin_context = _PluginContext(root)
+        self.logger = _Logger()
+
+
+def test_daily_json_backup_is_atomic_and_private(tmp_path):
+    service = SleepMaintenanceService(_DeepMind(tmp_path))
+    state = {}
+
+    status = asyncio.run(service._task_daily_json_backup(state))
+
+    today = time.strftime("%Y%m%d", time.localtime())
+    backup_file = tmp_path / "backups" / f"memory_backup_{today}.json"
+    assert status == "success"
+    assert state["daily_json_backup_last_day"] == today
+    assert json.loads(backup_file.read_text(encoding="utf-8"))["records"] == [
+        {"id": "memory-1"}
+    ]
+    assert list((tmp_path / "backups").glob(".*.tmp")) == []
+    if os.name == "posix":
+        assert stat.S_IMODE(backup_file.stat().st_mode) == 0o600

--- a/tests/test_atomic_daily_backup.py
+++ b/tests/test_atomic_daily_backup.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import os
 import stat
 import sys
 import time
 from pathlib import Path
+
+import pytest
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
@@ -19,15 +22,22 @@ from astrbot_plugin_angel_memory.core.services.sleep_maintenance_service import 
 
 
 class _Logger:
+    def __init__(self):
+        self.warnings = []
+
     def info(self, *args, **kwargs):
         pass
 
     def warning(self, *args, **kwargs):
-        pass
+        self.warnings.append((args, kwargs))
 
 
 class _MemoryManager:
+    def __init__(self):
+        self.export_calls = 0
+
     async def export_backup_snapshot(self):
+        self.export_calls += 1
         return {"records": [{"id": "memory-1"}], "global_tags": []}
 
 
@@ -50,18 +60,84 @@ class _DeepMind:
 
 
 def test_daily_json_backup_is_atomic_and_private(tmp_path):
+    backup_dir = tmp_path / "backups"
+    if os.name == "posix":
+        backup_dir.mkdir(mode=0o777)
+        backup_dir.chmod(0o777)
+
     service = SleepMaintenanceService(_DeepMind(tmp_path))
     state = {}
 
     status = asyncio.run(service._task_daily_json_backup(state))
 
     today = time.strftime("%Y%m%d", time.localtime())
-    backup_file = tmp_path / "backups" / f"memory_backup_{today}.json"
+    backup_file = backup_dir / f"memory_backup_{today}.json"
     assert status == "success"
     assert state["daily_json_backup_last_day"] == today
     assert json.loads(backup_file.read_text(encoding="utf-8"))["records"] == [
         {"id": "memory-1"}
     ]
-    assert list((tmp_path / "backups").glob(".*.tmp")) == []
+    assert list(backup_dir.glob(".*.tmp")) == []
     if os.name == "posix":
+        assert stat.S_IMODE(backup_dir.stat().st_mode) == 0o700
         assert stat.S_IMODE(backup_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission contract")
+def test_backup_stops_when_private_directory_cannot_be_secured(monkeypatch, tmp_path):
+    deepmind = _DeepMind(tmp_path)
+    service = SleepMaintenanceService(deepmind)
+    original_chmod = Path.chmod
+
+    def guarded_chmod(path, mode, *args, **kwargs):
+        if path.name == "backups":
+            raise PermissionError("simulated chmod failure")
+        return original_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "chmod", guarded_chmod)
+
+    with pytest.raises(PermissionError, match="simulated chmod failure"):
+        asyncio.run(service._task_daily_json_backup({}))
+
+    assert deepmind.plugin_context.manager.export_calls == 0
+    assert list((tmp_path / "backups").glob("memory_backup_*.json")) == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-specific")
+def test_unsupported_directory_fsync_still_marks_backup_complete(monkeypatch, tmp_path):
+    deepmind = _DeepMind(tmp_path)
+    service = SleepMaintenanceService(deepmind)
+    state = {}
+    real_fsync = os.fsync
+
+    def fsync_with_unsupported_directory(fd):
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(errno.EINVAL, "directory fsync unsupported")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fsync_with_unsupported_directory)
+
+    assert asyncio.run(service._task_daily_json_backup(state)) == "success"
+    assert asyncio.run(service._task_daily_json_backup(state)) == "skipped"
+    assert deepmind.plugin_context.manager.export_calls == 1
+    assert deepmind.logger.warnings
+
+
+@pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-specific")
+def test_real_directory_fsync_error_is_not_swallowed(monkeypatch, tmp_path):
+    service = SleepMaintenanceService(_DeepMind(tmp_path))
+    state = {}
+    real_fsync = os.fsync
+
+    def fsync_with_io_error(fd):
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(errno.EIO, "simulated I/O failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fsync_with_io_error)
+
+    with pytest.raises(OSError) as exc_info:
+        asyncio.run(service._task_daily_json_backup(state))
+
+    assert exc_info.value.errno == errno.EIO
+    assert "daily_json_backup_last_day" not in state

--- a/tests/test_rerank_failover.py
+++ b/tests/test_rerank_failover.py
@@ -1,0 +1,150 @@
+import asyncio
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(PLUGIN_ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT.parent))
+
+from astrbot_plugin_angel_memory.core.rerank_failover import FailoverRerankProvider
+
+
+class _FailingProvider:
+    def __init__(self):
+        self.calls = 0
+
+    async def rerank(self, **kwargs):
+        self.calls += 1
+        raise RuntimeError("remote unavailable")
+
+
+class _WorkingProvider:
+    def __init__(self):
+        self.calls = 0
+
+    async def rerank(self, **kwargs):
+        self.calls += 1
+        return [{"index": 0, "relevance_score": 0.9}]
+
+
+class _CapturingProvider(_WorkingProvider):
+    def __init__(self):
+        super().__init__()
+        self.documents = []
+        self.top_n = None
+
+    async def rerank(self, **kwargs):
+        self.documents = kwargs["documents"]
+        self.top_n = kwargs["top_n"]
+        return await super().rerank(**kwargs)
+
+
+class _ServerError(RuntimeError):
+    status = 500
+
+
+class _OverflowThenWorkingProvider(_WorkingProvider):
+    def __init__(self):
+        super().__init__()
+        self.document_lengths = []
+
+    async def rerank(self, **kwargs):
+        self.calls += 1
+        self.document_lengths.append([len(doc) for doc in kwargs["documents"]])
+        if self.calls == 1:
+            raise _ServerError("Internal Server Error")
+        return [{"index": 0, "relevance_score": 0.9}]
+
+
+class _ProviderWithoutTopN:
+    def __init__(self):
+        self.calls = 0
+
+    async def rerank(self, query, documents):
+        self.calls += 1
+        assert query == "query"
+        assert documents == ["one", "two"]
+        return [
+            {"index": 0, "relevance_score": 0.9},
+            {"index": 1, "relevance_score": 0.8},
+        ]
+
+
+def test_rerank_falls_back_after_primary_failure():
+    primary = _FailingProvider()
+    fallback = _WorkingProvider()
+    provider = FailoverRerankProvider(
+        [("remote", primary), ("local", fallback)],
+        failure_threshold=3,
+        cooldown_seconds=60,
+    )
+
+    result = asyncio.run(provider.rerank("query", ["document"], top_n=1))
+
+    assert result[0]["index"] == 0
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+def test_rerank_circuit_breaker_skips_failed_primary():
+    primary = _FailingProvider()
+    fallback = _WorkingProvider()
+    provider = FailoverRerankProvider(
+        [("remote", primary), ("local", fallback)],
+        failure_threshold=2,
+        cooldown_seconds=60,
+    )
+
+    for _ in range(3):
+        result = asyncio.run(provider.rerank("query", ["document"], top_n=1))
+        assert result
+
+    assert primary.calls == 2
+    assert fallback.calls == 3
+
+
+def test_local_fallback_workload_is_bounded_without_affecting_primary():
+    primary = _FailingProvider()
+    fallback = _CapturingProvider()
+    provider = FailoverRerankProvider(
+        [("remote", primary), ("local", fallback)],
+        fallback_max_documents=2,
+        fallback_max_document_chars=20,
+    )
+    documents = ["a" * 40, "b" * 10, "c" * 10]
+
+    result = asyncio.run(provider.rerank("query", documents, top_n=3))
+
+    assert result
+    assert len(fallback.documents) == 2
+    assert len(fallback.documents[0]) == 20
+    assert fallback.documents[0].startswith("a" * 11)
+    assert fallback.documents[0].endswith("a" * 4)
+    assert fallback.top_n == 2
+
+
+def test_local_batch_overflow_retries_with_shorter_documents():
+    primary = _FailingProvider()
+    fallback = _OverflowThenWorkingProvider()
+    provider = FailoverRerankProvider(
+        [("remote", primary), ("local", fallback)],
+        fallback_max_document_chars=520,
+        fallback_retry_document_chars=220,
+    )
+
+    result = asyncio.run(provider.rerank("query", ["文" * 500], top_n=1))
+
+    assert result
+    assert fallback.calls == 2
+    assert fallback.document_lengths == [[500], [220]]
+
+
+def test_provider_without_top_n_parameter_remains_compatible():
+    underlying = _ProviderWithoutTopN()
+    provider = FailoverRerankProvider([("legacy", underlying)])
+
+    result = asyncio.run(provider.rerank("query", ["one", "two"], top_n=1))
+
+    assert underlying.calls == 1
+    assert [item["index"] for item in result] == [0]

--- a/tests/test_rerank_failover.py
+++ b/tests/test_rerank_failover.py
@@ -66,8 +66,8 @@ class _ProviderWithoutTopN:
         assert query == "query"
         assert documents == ["one", "two"]
         return [
-            {"index": 0, "relevance_score": 0.9},
-            {"index": 1, "relevance_score": 0.8},
+            {"index": 0, "relevance_score": 0.1},
+            {"index": 1, "relevance_score": 0.9},
         ]
 
 
@@ -140,11 +140,11 @@ def test_local_batch_overflow_retries_with_shorter_documents():
     assert fallback.document_lengths == [[500], [220]]
 
 
-def test_provider_without_top_n_parameter_remains_compatible():
+def test_provider_without_top_n_parameter_uses_highest_scores():
     underlying = _ProviderWithoutTopN()
     provider = FailoverRerankProvider([("legacy", underlying)])
 
     result = asyncio.run(provider.rerank("query", ["one", "two"], top_n=1))
 
     assert underlying.calls == 1
-    assert [item["index"] for item in result] == [0]
+    assert [item["index"] for item in result] == [1]


### PR DESCRIPTION
## 概要

- 为可选 rerank Provider 增加主备链、熔断冷却及本地批量过长时的缩短重试
- 兼容 AstrBot 原生 rerank Provider 与 OpenAI-compatible /rerank 端点，并对不支持 top_n 的实现安全切片
- 将每日中央记忆 JSON 备份改为同目录临时文件、fsync 与原子替换，避免中断留下半文件
- 增加配置项与回归测试

## 验证

- 纯 upstream/master 工作树：102 passed
- 私有整合工作树：159 passed, 2 subtests passed
- WebUI npm run build 通过
- 私密标记扫描通过；本 PR 不包含任何服务器 UMO、记忆域映射或部署配置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增重排序备用服务配置，主服务失败时可按顺序自动切换。
  * 支持失败熔断与冷却、备用服务文档数量及长度限制，并可在本地服务出错时缩短文档重试。
  * 支持配置主重排超时、失败阈值及相关默认值。

* **问题修复**
  * 优化每日 JSON 备份流程，强化目录和文件权限校验，降低备份失败及数据损坏风险。
  * 改进备份异常处理，在不支持部分系统操作时保持兼容，并正确报告其他失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->